### PR TITLE
Extract to json update

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # ipumsr (development version)
 
+* Include endpoint information (IPUMS collection and API version) when saving an extract as json.
+
+* Read endpoint information (IPUMS collection and API version) from json when they are included.
+
 # ipumsr 0.4.5
 
 * Fixed bug causing a read error for some labeled string variables (#61, thanks 

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -8,6 +8,7 @@ Contributors:
   Joe Grover, IPUMS, University of Minnesota
   Derek Burk, IPUMS, University of Minnesota
   Jacob Kaplan, University of Pennsylvania
+  Renae Rodgers, IPUMS, University of Minnesota
 
 This project is licensed under the Mozilla Public License, version 2.0 (the
 "License"). A copy of the License is in the project file "LICENSE.txt",

--- a/R/api.R
+++ b/R/api.R
@@ -1347,6 +1347,8 @@ extract_list_from_json <- function(extracts_as_json,
   purrr::map(
     list_of_extract_info,
     function(x) {
+      # if the collection kwarg is missing, check for it in the json
+      if (is.na(collection)) collection = x$collection
       out <- new_ipums_extract(
         collection = collection,
         description = x$description,

--- a/R/api.R
+++ b/R/api.R
@@ -112,7 +112,7 @@ define_extract_micro <- function(collection,
 #' extract_json_path <- file.path(tempdir(), "usa_extract.json")
 #' save_extract_as_json(my_extract, file = extract_json_path)
 #'
-#' copy_of_my_extract <- define_extract_from_json(extract_json_path, "usa")
+#' copy_of_my_extract <- define_extract_from_json(extract_json_path)
 #'
 #' identical(my_extract, copy_of_my_extract)
 #'

--- a/R/api.R
+++ b/R/api.R
@@ -167,7 +167,7 @@ define_extract_from_json <- function(extract_json) {
 #' extract_json_path <- file.path(tempdir(), "usa_extract.json")
 #' save_extract_as_json(my_extract, file = extract_json_path)
 #'
-#' copy_of_my_extract <- define_extract_from_json(extract_json_path, "usa")
+#' copy_of_my_extract <- define_extract_from_json(extract_json_path)
 #'
 #' identical(my_extract, copy_of_my_extract)
 #'

--- a/R/api.R
+++ b/R/api.R
@@ -1142,7 +1142,9 @@ extract_to_request_json <- function(extract) {
     ),
     data_format = extract$data_format,
     samples = format_samples_for_json(extract$samples),
-    variables = format_variables_for_json(extract$variables)
+    variables = format_variables_for_json(extract$variables),
+    collection = extract$collection,
+    api_version = microdata_api_version()
   )
   jsonlite::toJSON(request_list, auto_unbox = TRUE)
 }

--- a/R/api.R
+++ b/R/api.R
@@ -117,23 +117,9 @@ define_extract_micro <- function(collection,
 #' identical(my_extract, copy_of_my_extract)
 #'
 #' @export
-define_extract_from_json <- function(extract_json, collection) {
-  if (missing(collection)) {
-    stop("`collection` is a required argument", call. = FALSE)
-  }
-  if (!collection %in% ipums_data_collections()$code_for_api) {
-    stop(
-      paste0(
-        '"', collection, '"', " is not a valid code for an IPUMS data ",
-        "collection. To see all valid collection codes, use ",
-        "`ipums_data_collections()`"
-      ),
-      call. = FALSE
-    )
-  }
+define_extract_from_json <- function(extract_json) {
   list_of_extracts <- extract_list_from_json(
     extract_json,
-    collection,
     validate = TRUE
   )
   if (length(list_of_extracts) != 1) {
@@ -1350,7 +1336,7 @@ extract_list_from_json <- function(extracts_as_json,
     list_of_extract_info,
     function(x) {
       out <- new_ipums_extract(
-        collection = collection,
+        collection = x$collection,
         description = x$description,
         data_structure = names(x$data_structure),
         rectangular_on = ifelse(

--- a/R/api.R
+++ b/R/api.R
@@ -131,6 +131,15 @@ define_extract_from_json <- function(extract_json) {
       call. = FALSE
     )
   }
+  json_api_version <- api_version_from_json(extract_json)
+  if (microdata_api_version() != json_api_version){
+    warning(
+      "The extract defined in ", extract_json, " was made using API version ",
+      json_api_version, ". ipumsr is currently configured to submit extract ", 
+      "requests using API version ", microdata_api_version(), ".",
+      call. = FALSE
+    )
+  }
   list_of_extracts[[1]]
 }
 
@@ -1475,6 +1484,13 @@ microdata_api_version <- function() {
   api_version
 }
 
+api_version_from_json <- function(extract_json) {
+  extract <- jsonlite::fromJSON(
+    extract_json,
+    simplifyVector = FALSE
+  )
+  extract$api_version
+}
 
 EMPTY_NAMED_LIST <- setNames(list(), character(0))
 

--- a/tests/testthat/test_api.R
+++ b/tests/testthat/test_api.R
@@ -373,7 +373,7 @@ test_that("We can export to and import from JSON", {
   json_tmpfile <- file.path(tempdir(), "usa_extract.json")
   on.exit(unlink(json_tmpfile))
   save_extract_as_json(usa_extract, json_tmpfile)
-  copy_of_usa_extract <- define_extract_from_json(json_tmpfile, "usa")
+  copy_of_usa_extract <- define_extract_from_json(json_tmpfile)
   expect_identical(usa_extract, copy_of_usa_extract)
 })
 
@@ -382,7 +382,7 @@ test_that("We can export to and import from JSON, submitted extract", {
   json_tmpfile <- file.path(tempdir(), "usa_extract.json")
   on.exit(unlink(json_tmpfile))
   save_extract_as_json(submitted_usa_extract, json_tmpfile)
-  copy_of_submitted_usa_extract <- define_extract_from_json(json_tmpfile, "usa")
+  copy_of_submitted_usa_extract <- define_extract_from_json(json_tmpfile)
   expect_identical(
     ipumsr:::copy_ipums_extract(submitted_usa_extract),
     copy_of_submitted_usa_extract


### PR DESCRIPTION
Oops. Re-doing this on the ipums/ipumsr fork

I updated the functions that save an extract to a json file and define an extract from a json file to include the necessary API endpoint information to be able to re-create and submit an extract from a json file. The benefits of this are:

1. An extract defined from a json file can now be submitted as-is with
    extract <- define_extract_from_json("extract.json") submitted_extract <- submit_extract(extract)
2. The extract definition json is now inline with what is written and expected by ipumspy, making it possible to re-create an extract made using ipumsr with ipumspy and vice versa!

