### PR TITLE
Improve extract revision warnings

### DIFF
--- a/R/api.R
+++ b/R/api.R
@@ -745,8 +745,6 @@ download_extract <- function(extract,
 #'   Use the [USA sample ID values](https://usa.ipums.org/usa-action/samples/sample_ids)
 #'   or the [CPS sample ID values](https://cps.ipums.org/cps-action/samples/sample_ids).
 #' @param variables Character vector of variables to add to the extract, if any.
-#' @param validate Logical value indicating whether to check the modified
-#'   extract structure for validity. Defaults to `TRUE`.
 #' @param ... Further arguments passed to methods.
 #'
 #' @family ipums_api
@@ -801,7 +799,6 @@ add_to_extract.usa_extract <- function(extract,
                                        samples = NULL,
                                        variables = NULL,
                                        data_format = NULL,
-                                       validate = TRUE,
                                        ...) {
 
   add_to_extract_micro(
@@ -810,9 +807,9 @@ add_to_extract.usa_extract <- function(extract,
     samples = samples,
     variables = variables,
     data_format = data_format,
-    validate = validate,
     ...
   )
+
 }
 
 
@@ -823,7 +820,6 @@ add_to_extract.cps_extract <- function(extract,
                                        samples = NULL,
                                        variables = NULL,
                                        data_format = NULL,
-                                       validate = TRUE,
                                        ...) {
 
   add_to_extract_micro(
@@ -832,9 +828,9 @@ add_to_extract.cps_extract <- function(extract,
     samples = samples,
     variables = variables,
     data_format = data_format,
-    validate = validate,
     ...
   )
+
 }
 
 
@@ -857,8 +853,6 @@ add_to_extract.cps_extract <- function(extract,
 #'   if any.
 #' @param variables Character vector of variables to remove from the extract,
 #'   if any.
-#' @param validate Logical value indicating whether to check the modified
-#'   extract structure for validity. Defaults to `TRUE`.
 #' @param ... Further arguments passed to methods.
 #'
 #' @family ipums_api
@@ -908,16 +902,15 @@ remove_from_extract <- function(extract, ...) {
 remove_from_extract.usa_extract <- function(extract,
                                             samples = NULL,
                                             variables = NULL,
-                                            validate = TRUE,
                                             ...) {
 
   remove_from_extract_micro(
     extract = extract,
     samples = samples,
     variables = variables,
-    validate = validate,
     ...
   )
+
 }
 
 
@@ -926,16 +919,15 @@ remove_from_extract.usa_extract <- function(extract,
 remove_from_extract.cps_extract <- function(extract,
                                             samples = NULL,
                                             variables = NULL,
-                                            validate = TRUE,
                                             ...) {
 
   remove_from_extract_micro(
     extract = extract,
     samples = samples,
     variables = variables,
-    validate = validate,
     ...
   )
+
 }
 
 
@@ -1775,10 +1767,20 @@ add_to_extract_micro <- function(extract,
                                  data_format = NULL,
                                  data_structure = NULL,
                                  rectangular_on = NULL,
-                                 validate = TRUE,
                                  ...) {
 
   extract <- copy_ipums_extract(extract)
+
+  dots <- rlang::list2(...)
+
+  if (length(dots) > 0) {
+    warning(
+      "The following fields were either not found in the provided extract ",
+      "or cannot be modified: `",
+      paste0(names(dots), collapse = "`, `"), "`",
+      call. = FALSE
+    )
+  }
 
   if (!is.null(data_structure) && data_structure != "rectangular") {
     stop(
@@ -1834,9 +1836,7 @@ add_to_extract_micro <- function(extract,
     modification = "replace"
   )
 
-  if (validate) {
-    extract <- validate_ipums_extract(extract)
-  }
+  extract <- validate_ipums_extract(extract)
 
   extract
 
@@ -1850,17 +1850,23 @@ add_to_extract_micro <- function(extract,
 remove_from_extract_micro <- function(extract,
                                       samples = NULL,
                                       variables = NULL,
-                                      validate = TRUE,
                                       ...) {
 
   extract <- copy_ipums_extract(extract)
 
-  extract <- validate_remove_fields(
-    extract,
-    bad_remove_fields = c("description", "data_format",
-                          "data_structure", "rectangular_on"),
-    ...
-  )
+
+  dots <- rlang::list2(...)
+
+  if (length(dots) > 0) {
+    warning(
+      "The following fields were either not found in the provided extract ",
+      "or cannot be removed: `",
+      paste0(names(dots), collapse = "`, `"), "`\n",
+      "See `add_to_extract()` to replace existing values in applicable extract ",
+      "fields.",
+      call. = FALSE
+    )
+  }
 
   to_remove <- list(
     samples = samples,
@@ -1890,9 +1896,20 @@ remove_from_extract_micro <- function(extract,
     modification = "remove"
   )
 
-  if (validate) {
-    extract <- validate_ipums_extract(extract)
-  }
+  # I believe the only way to produce an invalid extract from removal is
+  # to remove all fields of a certain value. This takes advantage of this fact
+  # to improve the validation error message.
+  tryCatch(
+    extract <- validate_ipums_extract(extract),
+    error = function(cond) {
+      stop(
+        conditionMessage(cond),
+        "\nTo replace existing values in an extract, first add new values ",
+        "with `add_to_extract()`, then remove existing ones.",
+        call. = FALSE
+      )
+    }
+  )
 
   extract
 
@@ -1974,60 +1991,6 @@ modify_flat_fields <- function(extract,
       }
     )
 
-  }
-
-  extract
-
-}
-
-#' Produce warnings for invalid extract revision requests
-#'
-#' Convenience function to throw more informative warnings on invalid extract
-#' revision specifications. Currently used to direct users to
-#' \code{add_to_extract()} when attempting to remove non-optional fields in
-#' \code{remove_from_extract()}. (Otherwise, users would face a potentially
-#' unexpected unused argument error)
-#'
-#' @param extract An extract object
-#' @param bad_remove_fields Character vector of names of fields that should
-#'   trigger warnings if user attempts to remove them from an extract
-#' @param ... Arbitrary selection of named arguments. Used to warn against use
-#'   of extract fields that do not exist in the extract.
-#'
-#' @noRd
-validate_remove_fields <- function(extract, bad_remove_fields, ...) {
-
-  dots <- rlang::list2(...)
-
-  if ("collection" %in% names(dots)) {
-    stop(
-      "Cannot modify collection of an existing extract. To create an extract",
-      " from a new collection, use the appropriate `define_extract_` function.",
-      call. = FALSE
-    )
-  }
-
-  tried_to_remove <- bad_remove_fields[bad_remove_fields %in% names(dots)]
-  invalid_fields <- names(dots)[!names(dots) %in% bad_remove_fields]
-
-  if (length(tried_to_remove) > 0) {
-    warning(
-      "The following fields cannot be removed from an object of class `",
-      paste0(extract$collection, "_extract"), "`: `",
-      paste0(tried_to_remove, collapse = "`, `"), "`.\nTo ",
-      "replace these values, use add_to_extract().",
-      call. = FALSE
-    )
-  }
-
-  if (length(invalid_fields) > 0) {
-    warning(
-      "The following were not recognized as valid fields for an object of ",
-      "class `", paste0(extract$collection, "_extract"), "`: `",
-      paste0(invalid_fields, collapse = "`, `"),
-      "`. These values will be ignored.",
-      call. = FALSE
-    )
   }
 
   extract

--- a/man/add_to_extract.Rd
+++ b/man/add_to_extract.Rd
@@ -14,7 +14,6 @@ add_to_extract(extract, ...)
   samples = NULL,
   variables = NULL,
   data_format = NULL,
-  validate = TRUE,
   ...
 )
 
@@ -24,7 +23,6 @@ add_to_extract(extract, ...)
   samples = NULL,
   variables = NULL,
   data_format = NULL,
-  validate = TRUE,
   ...
 )
 }
@@ -43,9 +41,6 @@ or the \href{https://cps.ipums.org/cps-action/samples/sample_ids}{CPS sample ID 
 
 \item{data_format}{The desired format of the extract data file (one of
 "fixed_width", "csv", "stata", "spss", or "sas9").}
-
-\item{validate}{Logical value indicating whether to check the modified
-extract structure for validity. Defaults to \code{TRUE}.}
 }
 \value{
 A modified IPUMS USA or CPS extract object

--- a/man/remove_from_extract.Rd
+++ b/man/remove_from_extract.Rd
@@ -8,21 +8,9 @@
 \usage{
 remove_from_extract(extract, ...)
 
-\method{remove_from_extract}{usa_extract}(
-  extract,
-  samples = NULL,
-  variables = NULL,
-  validate = TRUE,
-  ...
-)
+\method{remove_from_extract}{usa_extract}(extract, samples = NULL, variables = NULL, ...)
 
-\method{remove_from_extract}{cps_extract}(
-  extract,
-  samples = NULL,
-  variables = NULL,
-  validate = TRUE,
-  ...
-)
+\method{remove_from_extract}{cps_extract}(extract, samples = NULL, variables = NULL, ...)
 }
 \arguments{
 \item{extract}{An \code{\link[=ipums_extract-class]{ipums_extract}} object.}
@@ -34,9 +22,6 @@ if any.}
 
 \item{variables}{Character vector of variables to remove from the extract,
 if any.}
-
-\item{validate}{Logical value indicating whether to check the modified
-extract structure for validity. Defaults to \code{TRUE}.}
 }
 \value{
 A modified IPUMS USA or CPS extract object

--- a/tests/testthat/test_api.R
+++ b/tests/testthat/test_api.R
@@ -570,14 +570,14 @@ test_that("Unused revisions do not alter CPS extract", {
 
 
 test_that("Improper extract revisions throw warnings or errors", {
-  # expect_warning(
-  #   add_to_extract(usa_extract, samples = "us2017b"),
-  #   regexp = "already included"
-  # )
-  # expect_warning(
-  #   remove_from_extract(cps_extract, variables = "RELATE"),
-  #   regexp = "are not included"
-  # )
+  expect_warning(
+    add_to_extract(usa_extract, samples = "us2017b"),
+    regexp = "already included"
+  )
+  expect_warning(
+    remove_from_extract(cps_extract, variables = "RELATE"),
+    regexp = "are not included"
+  )
   expect_warning(
     remove_from_extract(usa_extract,
                         description = "description",

--- a/tests/testthat/test_api.R
+++ b/tests/testthat/test_api.R
@@ -570,48 +570,58 @@ test_that("Unused revisions do not alter CPS extract", {
 
 
 test_that("Improper extract revisions throw warnings or errors", {
+  # expect_warning(
+  #   add_to_extract(usa_extract, samples = "us2017b"),
+  #   regexp = "already included"
+  # )
+  # expect_warning(
+  #   remove_from_extract(cps_extract, variables = "RELATE"),
+  #   regexp = "are not included"
+  # )
   expect_warning(
-    add_to_extract(usa_extract, samples = "us2017b"),
-    regexp = "already included"
-  )
-  expect_warning(
-    remove_from_extract(usa_extract, variables = "RELATE"),
-    regexp = "are not included"
-  )
-  expect_warning(
-    remove_from_extract(usa_extract, description = "description"),
+    remove_from_extract(usa_extract,
+                        description = "description",
+                        invalid = "invalid"),
     paste0(
-      "The following fields cannot be removed from an object of class ",
-      "`usa_extract`: `description`.\nTo replace these values"
+      "The following fields were either not found in the provided extract ",
+      "or cannot be removed: `description`, `invalid`\nSee ",
+      "`add_to_extract\\(\\)`"
     )
   )
   expect_warning(
-    remove_from_extract(usa_extract, bad_field = "bad field"),
+    add_to_extract(cps_extract,
+                   description = "description",
+                   invalid = "invalid"),
     paste0(
-      "The following were not recognized as valid fields for an object of class",
-      " `usa_extract`: `bad_field`."
-    )
-  )
-  expect_error(
-    remove_from_extract(usa_extract, samples = usa_extract$samples),
-    paste0(
-      "The following elements of an extract definition must not contain missing",
-      " values: samples"
+      "The following fields were either not found in the provided extract ",
+      "or cannot be modified: `invalid`"
     )
   )
   expect_silent(
+    add_to_extract(cps_extract, description = "description")
+  )
+  expect_error(
     remove_from_extract(
       usa_extract,
       samples = usa_extract$samples,
-      validate = FALSE
+      variables = usa_extract$variables
+    ),
+    paste0(
+      "The following elements of an extract definition must not contain missing",
+      " values: samples, variables"
     )
   )
   expect_error(
-    remove_from_extract(usa_extract, variables = usa_extract$variables),
-    paste0(
-      "The following elements of an extract definition must not contain missing",
-      " values: variables"
-    )
+    add_to_extract(usa_extract, data_format = "bad_format"),
+    "x\\$data_format %in% c\\(\"fixed_width\""
+  )
+  expect_warning(
+    add_to_extract(
+      usa_extract,
+      samples = "New Sample",
+      data_format = c("csv", "bad_format"),
+    ),
+    "Multiple values passed to `data_format`, which must be length 1"
   )
 })
 


### PR DESCRIPTION
Any unused extract arguments produce warnings during extract revision. Also removes `validate` argument from extract revision functions and instead suggests that users use `add_to_extract()` before `remove_from_extract()` if they produce an invalid extract with `remove_from_extract()`. 