### PR TITLE
Move raster to suggests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,6 @@ Imports:
     hipread (>= 0.2.0),
     purrr,
     R6,
-    raster,
     readr,
     rlang,
     tibble,
@@ -53,5 +52,6 @@ Suggests:
     RSQLite,
     dbplyr,
     vcr (>= 0.6.0),
-    withr
+    withr,
+    raster
 VignetteBuilder: knitr

--- a/R/terra_read.r
+++ b/R/terra_read.r
@@ -5,8 +5,13 @@
 
 #' Read data from an IPUMS Terra raster extract
 #'
+#' @description
 #' Read a single raster datasets downloaded from the IPUMS Terra extract system using
 #' \code{read_terra_raster}, or read multiple into a list using \code{read_terra_raster_list}.
+#'
+#' \emph{Note: Reading IPUMS Terra raster extracts requires installation of the
+#' raster package, which is no longer installed automatically when you install
+#' ipumsr.}
 #'
 #' @return
 #'   For \code{read_terra_raster} A \code{\link[raster]{raster}} object, for
@@ -50,6 +55,17 @@ read_terra_raster_list <- function(
 # by a function change based on the inputs. Therefore, the singular version loads directly
 # as raster, and the multi one always returns a list.
 read_terra_raster_internal <- function(data_file, data_layer, verbose, multiple_ok) {
+
+  # Check if raster package is installed
+  if (!requireNamespace("raster", quietly = TRUE)) {
+    stop(
+      "Reading IPUMS Terra raster extracts requires installation of the ",
+      "raster package, which is no longer installed automatically when you ",
+      "install ipumsr. Use `install.packages(\"raster\")` to install the ",
+      "raster package and then try again.", call. = FALSE
+    )
+  }
+
   # Read data files ----
     if (path_is_zip_or_dir(data_file)) {
       tiff_names <- find_files_in(data_file, "tiff", data_layer, multiple_ok = multiple_ok)

--- a/man/read_terra_raster.Rd
+++ b/man/read_terra_raster.Rd
@@ -27,6 +27,10 @@ For \code{read_terra_raster} A \code{\link[raster]{raster}} object, for
 \description{
 Read a single raster datasets downloaded from the IPUMS Terra extract system using
 \code{read_terra_raster}, or read multiple into a list using \code{read_terra_raster_list}.
+
+\emph{Note: Reading IPUMS Terra raster extracts requires installation of the
+raster R package, which is no longer installed automatically when you install
+ipumsr.}
 }
 \examples{
 \dontrun{

--- a/tests/testthat/test_terra.r
+++ b/tests/testthat/test_terra.r
@@ -6,6 +6,23 @@ ex_file <- function(x) {
   system.file("extdata", x, package = "ipumsexamples")
 }
 
+test_that("read_terra_raster throws error if raster isn't installed", {
+  raster_file <- ex_file("2552_bundle.zip")
+  if (!file.exists(raster_file)) {
+    skip("Couldn't find raster example file. ipumsexamples likely not installed.")
+  }
+  raster_path <- try(find.package("raster"), silent = TRUE)
+  if (!inherits(raster_path, "try-error")) {
+    renamed_path <- file.path(dirname(raster_path), "notraster")
+    on.exit(file.rename(renamed_path, raster_path))
+    stopifnot(file.rename(raster_path, renamed_path))
+  }
+  expect_error(
+    raster <- read_terra_raster_list(raster_file, verbose = FALSE),
+    regexp = "requires installation of the raster package"
+  )
+})
+
 test_that("Terra raster works", {
   raster_file <- ex_file("2552_bundle.zip")
   if (!file.exists(raster_file)) {


### PR DESCRIPTION
Since the raster package is only used to read raster extracts from the IPUMS Terra project, which is slated to be decommissioned, we are moving the raster package from Imports to Suggests. This means raster will not be installed automatically when you install ipumsr.