### PR TITLE
Add progress bar to extract download

### DIFF
--- a/R/api.R
+++ b/R/api.R
@@ -1559,7 +1559,8 @@ ipums_api_download_request <- function(url,
       )
     ),
     add_user_auth_header(api_key),
-    httr::write_disk(file_path, overwrite = TRUE)
+    httr::write_disk(file_path, overwrite = TRUE),
+    httr::progress()
   )
 
   if (httr::http_status(response)$category != "Success") {


### PR DESCRIPTION
Adds progress bar when using `download_extract()`. Makes it clear that things are working even when downloading larger files.