### PR TITLE
Read list rectangular session crash

### DIFF
--- a/R/bind_rows.R
+++ b/R/bind_rows.R
@@ -47,10 +47,16 @@
 ipums_bind_rows <- function(..., .id = NULL) {
   # TODO: Rewrite in C++?
   # Definitely not exactly the same logic as dplyr, but should cover most cases
-  d_list <- rlang::squash_if(
-    rlang::dots_values(...),
-    function(x) is.list(x) && !is.data.frame(x)
-  )
+  d_list <- purrr::list_flatten(list(...))
+
+  if (!all(purrr::map_lgl(d_list, is.data.frame))) {
+    rlang::abort(
+      paste0(
+        "Each argument to `ipums_bind_rows()` must be a data.frame or a ",
+        "list of data.frames."
+      )
+    )
+  }
 
   unique_var_names <- unique(purrr::flatten_chr(purrr::map(d_list, names)))
 

--- a/R/micro_read.R
+++ b/R/micro_read.R
@@ -264,32 +264,22 @@ read_ipums_micro_list <- function(
     ddi <- read_ipums_ddi(ddi, lower_vars = lower_vars)
   }
 
-  # If the file type is rectangular, it can be handled by read_ipums_micro()
+  # If the file type is rectangular, direct users to read_ipums_micro()
   if (ddi$file_type == "rectangular") {
-    out <- read_ipums_micro(
-      ddi,
-      vars = !!enquo(vars),
-      n_max = n_max,
-      data_file = data_file,
-      verbose = verbose,
-      var_attrs = var_attrs,
-      lower_vars = FALSE
+    rlang::abort(
+      c(
+        "Data file must be hierarchical, not rectangular.",
+        i = "For rectangular data, use `read_ipums_micro()`."
+      )
     )
-
-    if (verbose) {
-      cat("Assuming data rectangularized to 'P' record type")
-    }
-
-    return(list("P" = out))
   }
 
   if (is.null(data_file)) {
     data_file <- file.path(ddi$file_path, ddi$file_name)
   }
 
-  # We know the file is hierarchical because the function would have already
-  # returned if it was rectangular
-  if (ipums_file_ext(data_file) %in% c(".csv", ".csv.gz")) {
+  if (ipums_file_ext(data_file) %in% c(".csv", ".csv.gz") &
+      ddi$file_type == "hierarchical") {
     rlang::abort("Hierarchical data cannot be read as csv.")
   }
 

--- a/R/micro_read.R
+++ b/R/micro_read.R
@@ -264,8 +264,33 @@ read_ipums_micro_list <- function(
     ddi <- read_ipums_ddi(ddi, lower_vars = lower_vars)
   }
 
+  # If the file type is rectangular, it can be handled by read_ipums_micro()
+  if (ddi$file_type == "rectangular") {
+    out <- read_ipums_micro(
+      ddi,
+      vars = !!enquo(vars),
+      n_max = n_max,
+      data_file = data_file,
+      verbose = verbose,
+      var_attrs = var_attrs,
+      lower_vars = FALSE
+    )
+
+    if (verbose) {
+      cat("Assuming data rectangularized to 'P' record type")
+    }
+
+    return(list("P" = out))
+  }
+
   if (is.null(data_file)) {
     data_file <- file.path(ddi$file_path, ddi$file_name)
+  }
+
+  # We know the file is hierarchical because the function would have already
+  # returned if it was rectangular
+  if (ipums_file_ext(data_file) %in% c(".csv", ".csv.gz")) {
+    rlang::abort("Hierarchical data cannot be read as csv.")
   }
 
   data_file <- custom_check_file_exists(
@@ -287,45 +312,19 @@ read_ipums_micro_list <- function(
   rt_ddi <- get_rt_ddi(ddi)
   ddi <- ddi_filter_vars(ddi, vars, "list", verbose)
 
-  if (ipums_file_ext(data_file) %in% c(".csv", ".csv.gz")) {
-    if (ddi$file_type == "hierarchical") {
-      rlang::abort("Hierarchical data cannot be read as csv.")
-    }
+  rt_info <- ddi_to_rtinfo(rt_ddi)
+  col_spec <- ddi_to_colspec(ddi, "list", verbose)
 
-    col_types <- ddi_to_readr_colspec(ddi)
+  out <- hipread::hipread_list(
+    data_file,
+    col_spec,
+    rt_info,
+    progress = show_readr_progress(verbose),
+    n_max = n_max,
+    encoding = ddi$file_encoding
+  )
 
-    out <- readr::read_csv(
-      data_file,
-      col_types = col_types,
-      n_max = n_max,
-      locale = ipums_locale(ddi$file_encoding),
-      progress = show_readr_progress(verbose)
-    )
-
-    if (ddi_has_lowercase_var_names(ddi)) {
-      out <- dplyr::rename_all(out, tolower)
-    }
-
-    if (verbose) {
-      cat("Assuming data rectangularized to 'P' record type")
-    }
-
-    out <- list("P" = out)
-  } else {
-    rt_info <- ddi_to_rtinfo(rt_ddi)
-    col_spec <- ddi_to_colspec(ddi, "list", verbose)
-
-    out <- hipread::hipread_list(
-      data_file,
-      col_spec,
-      rt_info,
-      progress = show_readr_progress(verbose),
-      n_max = n_max,
-      encoding = ddi$file_encoding
-    )
-
-    names(out) <- rectype_label_names(names(out), rt_ddi)
-  }
+  names(out) <- rectype_label_names(names(out), rt_ddi)
 
   for (rt in names(out)) {
     out[[rt]] <- set_ipums_var_attributes(out[[rt]], ddi, var_attrs)

--- a/tests/testthat/test_ipums_bind_rows.R
+++ b/tests/testthat/test_ipums_bind_rows.R
@@ -37,3 +37,43 @@ test_that("mismatched attributes in bind rows", {
   expect_equal(names(bound), c("x", "y", "z"))
   expect_equal(as.vector(bound$x), c(1, 2, 3, 1))
 })
+
+
+test_that("ipums_bind_rows can handle list of data.frames", {
+  test1 <- tibble::tibble(
+    x = haven::labelled(c(1, 2, 3), c("xyz" = 1)),
+    y = 2:4
+  )
+  attr(test1$x, "label") <- "A var label"
+
+  test2 <- tibble::tibble(
+    x = haven::labelled(c(1), c("xyz" = 1)),
+    z = "a"
+  )
+  attr(test2$x, "label") <- "A var label"
+
+  bound <- ipums_bind_rows(test1, list(test1, test2))
+
+  expect_equal(names(bound), c("x", "y", "z"))
+  expect_equal(as.vector(bound$x), c(1, 2, 3, 1, 2, 3, 1))
+})
+
+
+test_that("ipums_bind_rows throws error for nested list of data.frames", {
+  test1 <- tibble::tibble(
+    x = haven::labelled(c(1, 2, 3), c("xyz" = 1)),
+    y = 2:4
+  )
+  attr(test1$x, "label") <- "A var label"
+
+  test2 <- tibble::tibble(
+    x = haven::labelled(c(1), c("xyz" = 1)),
+    z = "a"
+  )
+  attr(test2$x, "label") <- "A var label"
+
+  expect_error(
+    ipums_bind_rows(test1, list(list(test1, test2))),
+    regexp = "must be a data.frame or a list of data.frames"
+  )
+})

--- a/tests/testthat/test_micro.R
+++ b/tests/testthat/test_micro.R
@@ -109,6 +109,28 @@ test_that("Can read Hierarchical into list format", {
   expect_equal(cps$HOUSEHOLD$HWTSUPP[1], HWTSUPP_first5_values[1])
 })
 
+test_that("Can read Rectangular into list format", {
+  temp_file <- paste0(tempfile(), ".dat")
+
+  temp <- readr::read_lines(ipums_example("cps_00006.dat.gz"))
+  readr::write_lines(temp, temp_file)
+  on.exit(unlink(temp_file), add = TRUE, after = FALSE)
+
+  cps_list <- read_ipums_micro_list(
+    ipums_example("cps_00006.xml"),
+    data_file = temp_file,
+    verbose = FALSE
+  )
+
+  cps <- read_ipums_micro(
+    ipums_example("cps_00006.xml"),
+    data_file = temp_file,
+    verbose = FALSE
+  )
+
+  testthat::expect_identical(cps_list$P, cps)
+})
+
 test_that("Arguments n_max and vars work", {
   cps <- read_ipums_micro(
     ipums_example("cps_00010.xml"),

--- a/tests/testthat/test_micro.R
+++ b/tests/testthat/test_micro.R
@@ -109,26 +109,21 @@ test_that("Can read Hierarchical into list format", {
   expect_equal(cps$HOUSEHOLD$HWTSUPP[1], HWTSUPP_first5_values[1])
 })
 
-test_that("Can read Rectangular into list format", {
+test_that("Can't read Rectangular into list format", {
   temp_file <- paste0(tempfile(), ".dat")
 
   temp <- readr::read_lines(ipums_example("cps_00006.dat.gz"))
   readr::write_lines(temp, temp_file)
   on.exit(unlink(temp_file), add = TRUE, after = FALSE)
 
-  cps_list <- read_ipums_micro_list(
-    ipums_example("cps_00006.xml"),
-    data_file = temp_file,
-    verbose = FALSE
+  expect_error(
+    cps_list <- read_ipums_micro_list(
+      ipums_example("cps_00006.xml"),
+      data_file = temp_file,
+      verbose = FALSE
+    ),
+    regexp = "must be hierarchical"
   )
-
-  cps <- read_ipums_micro(
-    ipums_example("cps_00006.xml"),
-    data_file = temp_file,
-    verbose = FALSE
-  )
-
-  testthat::expect_identical(cps_list$P, cps)
 })
 
 test_that("Arguments n_max and vars work", {


### PR DESCRIPTION
These commits avoid a session crash is a user passes rectangular data to `read_ipums_micro_list()` by throwing an error that directs them to use `read_ipums_micro()` instead.

This PR also includes an unrelated tiny refactor to `ipums_bind_rows()` that removes a deprecated function from the rlang package.