### PR TITLE
Correctly convert extracts with multiple shapefiles in tbl conversion

### DIFF
--- a/R/deprec-extract-info.R
+++ b/R/deprec-extract-info.R
@@ -203,12 +203,20 @@ extract_tbl_to_list <- function(extract_tbl, validate = TRUE) {
           purrr::map(list(.data$time_series_tables), purrr::compact),
           error = function(cnd) list(NULL)
         ),
+        "shapefiles" = tryCatch(
+          purrr::map(list(.data$shapefiles), ~ purrr::compact(.x[!is.na(.x)])),
+          error = function(cnd) list(NULL)
+        ),
         "datasets" = purrr::map(
           .data$datasets,
           empty_to_null
         ),
         "time_series_tables" = purrr::map(
           .data$time_series_tables,
+          empty_to_null
+        ),
+        "shapefiles" = purrr::map(
+          .data$shapefiles,
           empty_to_null
         )
       ) %>%


### PR DESCRIPTION
`extract_tbl_to_list()` did not convert NHGIS extracts with multiple shapefiles correctly. These extract definitions were converted into multiple definitions; one for each shapefile included in the definition. This fix collapses shapefiles so they are all included in the original extract definition when converted from `tibble` to `list`.

Tibble-formatted extract history is being deprecated, but we might as well implement this fix until it is fully removed.