### PR TITLE
Deprecate certain file path options in ipumsr readers

### DIFF
--- a/R/ddi_read.R
+++ b/R/ddi_read.R
@@ -287,9 +287,15 @@ read_ipums_ddi <- function(ddi_file,
     }
   }
 
+  if (file_is_dir(ddi_file)) {
+    file_path <- ddi_file
+  } else {
+    file_path <- dirname(ddi_file)
+  }
+
   new_ipums_ddi(
     file_name = file_name,
-    file_path = dirname(ddi_file),
+    file_path = file_path,
     file_type = file_type,
     ipums_project = ipums_project,
     extract_date = extract_date,

--- a/R/ddi_read.R
+++ b/R/ddi_read.R
@@ -89,8 +89,8 @@ NULL
 #'   returns the path to the codebook file.
 #'
 #' @param ddi_file Path to a DDI .xml file downloaded from
-#'   [IPUMS](https://www.ipums.org/) or a .zip archive or directory containing
-#'   the .xml file. See *Downloading IPUMS files* below.
+#'   [IPUMS](https://www.ipums.org/) or a .zip archive containing the .xml file.
+#'   See *Downloading IPUMS files* below.
 #' @param file_select If `ddi_file` is a .zip archive or directory that contains
 #'   multiple .xml files, an expression identifying the file to read.
 #'   Accepts a character string specifying the file name, a
@@ -155,6 +155,8 @@ read_ipums_ddi <- function(ddi_file,
   }
 
   custom_check_file_exists(ddi_file)
+
+  dir_read_deprecated(ddi_file)
 
   ddi_file_load <- find_files_in(
     ddi_file,
@@ -508,6 +510,8 @@ get_var_info_from_ddi <- function(ddi_xml,
 read_nhgis_codebook <- function(cb_file,
                                 file_select = NULL,
                                 raw = FALSE) {
+  dir_read_deprecated(cb_file)
+
   file_select <- enquo(file_select)
 
   custom_check_file_exists(cb_file)

--- a/R/list_files.R
+++ b/R/list_files.R
@@ -3,13 +3,12 @@
 # in this project's top-level directory, and also on-line at:
 #   https://github.com/ipums/ipumsr
 
-#' List files contained within an IPUMS extract
+#' List files contained within a zipped IPUMS extract
 #'
-#' Identify the files that can be read from an IPUMS extract, whether its
-#' files are stored in a .zip archive or a directory.
+#' Identify the files that can be read from an IPUMS extract.
 #'
-#' @param file Path to a .zip archive or directory containing the IPUMS extract
-#'   to be examined.
+#' @param file Path to a .zip archive containing the IPUMS extract to be
+#'   examined.
 #' @param file_select If the path in `file` contains multiple files, a
 #'   [tidyselect selection][selection_language] identifying the files to be
 #'   included in the output. Only files that match the provided expression
@@ -53,6 +52,15 @@ ipums_list_files <- function(file,
   has_dl <- !missing(data_layer)
   has_sl <- !missing(shape_layer)
   has_rl <- !missing(raster_layer)
+
+  if (file_is_dir(file)) {
+    lifecycle::deprecate_warn(
+      "0.6.3",
+      I("Reading files through a directory "),
+      details = "Use `dir()` to list files in a directory.",
+      id = "dir_read"
+    )
+  }
 
   if (any(c(has_dl, has_sl, has_rl))) {
     lifecycle::deprecate_warn(

--- a/R/micro_read.R
+++ b/R/micro_read.R
@@ -167,8 +167,13 @@ read_ipums_micro <- function(
     verbose = TRUE,
     var_attrs = c("val_labels", "var_label", "var_desc"),
     lower_vars = FALSE) {
-  lower_vars_was_ignored <- check_if_lower_vars_ignored(ddi, lower_vars)
-  if (lower_vars_was_ignored) {
+  if (!inherits(ddi, "ipums_ddi") && (file_is_zip(ddi) || file_is_dir(ddi))) {
+    rlang::abort(
+      "Expected `ddi` to be an `ipums_ddi` object or the path to an .xml file."
+    )
+  }
+
+  if (check_if_lower_vars_ignored(ddi, lower_vars)) {
     rlang::warn(lower_vars_ignored_warning())
   }
 
@@ -259,8 +264,13 @@ read_ipums_micro_list <- function(
     verbose = TRUE,
     var_attrs = c("val_labels", "var_label", "var_desc"),
     lower_vars = FALSE) {
-  lower_vars_was_ignored <- check_if_lower_vars_ignored(ddi, lower_vars)
-  if (lower_vars_was_ignored) {
+  if (!inherits(ddi, "ipums_ddi") && (file_is_zip(ddi) || file_is_dir(ddi))) {
+    rlang::abort(
+      "Expected `ddi` to be an `ipums_ddi` object or the path to an .xml file."
+    )
+  }
+
+  if (check_if_lower_vars_ignored(ddi, lower_vars)) {
     rlang::warn(lower_vars_ignored_warning())
   }
 

--- a/R/micro_read_chunked.R
+++ b/R/micro_read_chunked.R
@@ -197,8 +197,13 @@ read_ipums_micro_chunked <- function(
     verbose = TRUE,
     var_attrs = c("val_labels", "var_label", "var_desc"),
     lower_vars = FALSE) {
-  lower_vars_was_ignored <- check_if_lower_vars_ignored(ddi, lower_vars)
-  if (lower_vars_was_ignored) {
+  if (!inherits(ddi, "ipums_ddi") && (file_is_zip(ddi) || file_is_dir(ddi))) {
+    rlang::abort(
+      "Expected `ddi` to be an `ipums_ddi` object or the path to an .xml file."
+    )
+  }
+
+  if (check_if_lower_vars_ignored(ddi, lower_vars)) {
     rlang::warn(lower_vars_ignored_warning())
   }
 
@@ -287,8 +292,13 @@ read_ipums_micro_list_chunked <- function(
     verbose = TRUE,
     var_attrs = c("val_labels", "var_label", "var_desc"),
     lower_vars = FALSE) {
-  lower_vars_was_ignored <- check_if_lower_vars_ignored(ddi, lower_vars)
-  if (lower_vars_was_ignored) {
+  if (!inherits(ddi, "ipums_ddi") && (file_is_zip(ddi) || file_is_dir(ddi))) {
+    rlang::abort(
+      "Expected `ddi` to be an `ipums_ddi` object or the path to an .xml file."
+    )
+  }
+
+  if (check_if_lower_vars_ignored(ddi, lower_vars)) {
     rlang::warn(lower_vars_ignored_warning())
   }
   if (is.character(ddi)) ddi <- read_ipums_ddi(ddi, lower_vars = lower_vars)

--- a/R/micro_read_yield.R
+++ b/R/micro_read_yield.R
@@ -133,6 +133,12 @@ read_ipums_micro_yield <- function(
     verbose = TRUE,
     var_attrs = c("val_labels", "var_label", "var_desc"),
     lower_vars = FALSE) {
+  if (!inherits(ddi, "ipums_ddi") && (file_is_zip(ddi) || file_is_dir(ddi))) {
+    rlang::abort(
+      "Expected `ddi` to be an `ipums_ddi` object or the path to an .xml file."
+    )
+  }
+
   vars <- enquo(vars)
 
   if (!is.null(var_attrs)) {
@@ -158,6 +164,12 @@ read_ipums_micro_list_yield <- function(
     verbose = TRUE,
     var_attrs = c("val_labels", "var_label", "var_desc"),
     lower_vars = FALSE) {
+  if (!inherits(ddi, "ipums_ddi") && (file_is_zip(ddi) || file_is_dir(ddi))) {
+    rlang::abort(
+      "Expected `ddi` to be an `ipums_ddi` object or the path to an .xml file."
+    )
+  }
+
   vars <- enquo(vars)
 
   if (!is.null(var_attrs)) {
@@ -189,8 +201,7 @@ IpumsLongYield <- R6::R6Class(
                           verbose = TRUE,
                           var_attrs = c("val_labels", "var_label", "var_desc"),
                           lower_vars = FALSE) {
-      lower_vars_was_ignored <- check_if_lower_vars_ignored(ddi, lower_vars)
-      if (lower_vars_was_ignored) {
+      if (check_if_lower_vars_ignored(ddi, lower_vars)) {
         rlang::warn(lower_vars_ignored_warning())
       }
 
@@ -264,8 +275,7 @@ IpumsListYield <- R6::R6Class(
                           verbose = TRUE,
                           var_attrs = c("val_labels", "var_label", "var_desc"),
                           lower_vars = FALSE) {
-      lower_vars_was_ignored <- check_if_lower_vars_ignored(ddi, lower_vars)
-      if (lower_vars_was_ignored) {
+      if (check_if_lower_vars_ignored(ddi, lower_vars)) {
         rlang::warn(lower_vars_ignored_warning())
       }
 

--- a/R/nhgis_read.R
+++ b/R/nhgis_read.R
@@ -25,9 +25,9 @@
 #' For more about resubmitting an existing extract via the IPUMS API, see
 #' `vignette("ipums-api", package = "ipumsr")`.
 #'
-#' @param data_file Path to a data file, a .zip archive from an NHGIS
-#'   extract, or a directory containing the data file.
-#' @param file_select If `data_file` is a .zip archive or directory that
+#' @param data_file Path to a .zip archive containing an NHGIS extract or
+#'   a single file from an NHGIS extract.
+#' @param file_select If `data_file` is a .zip archive that
 #'   contains multiple files, an expression identifying the file to load.
 #'   Accepts a character vector specifying the
 #'   file name, a [tidyselect selection][selection_language], or an index
@@ -61,8 +61,8 @@
 #'   the provided `data_file`. The .do file contains the parsing instructions
 #'   for the data file.
 #'
-#'   By default, looks in the same directory as `data_file` for a .do
-#'   file with the same name. See Details section below.
+#'   By default, looks in the same path as `data_file` for
+#'   a .do file with the same name. See Details section below.
 #' @param var_attrs Variable attributes to add from the codebook (.txt) file
 #'   included in the extract. Defaults to all available attributes.
 #'
@@ -140,6 +140,8 @@ read_nhgis <- function(data_file,
   if (length(data_file) != 1) {
     rlang::abort("`data_file` must be length 1")
   }
+
+  dir_read_deprecated(data_file)
 
   if (!missing(data_layer)) {
     lifecycle::deprecate_warn(
@@ -396,8 +398,8 @@ read_nhgis_csv <- function(data_file,
 #'
 #' An empty codebook is provided if no matching codebook can be found.
 #'
-#' @param data_file Path to a data file, a .zip archive from an NHGIS
-#'   extract, or a directory containing the data file.
+#' @param data_file Path to a data file or a .zip archive containing an NHGIS
+#'   extract.
 #' @param filename Name of the .csv or .dat file to be loaded within the
 #'   `data_file` zip archive. This allows codebooks to be identified when
 #'   `data_file` contains multiple files.

--- a/R/shape_read.R
+++ b/R/shape_read.R
@@ -22,9 +22,9 @@
 #' shapefiles, this function will throw an error. If this is the case, you may
 #' need to manually unzip the downloaded file before loading it into R.
 #'
-#' @param shape_file Path to a single .shp file, or a .zip archive or
-#'   directory containing at least one .shp file. See Details section.
-#' @param file_select If `shape_file` is a .zip archive or directory that
+#' @param shape_file Path to a single .shp file or a .zip archive
+#'   containing at least one .shp file. See Details section.
+#' @param file_select If `shape_file` is a .zip archive that
 #'   contains multiple files, an expression identifying the files to load.
 #'   Accepts a character string specifying the
 #'   file name, a [tidyselect selection][selection_language], or index
@@ -107,6 +107,8 @@ read_ipums_sf <- function(shape_file,
   } else {
     file_select <- enquo(file_select)
   }
+
+  dir_read_deprecated(shape_file)
 
   # dots <- rlang::list2(...)
   #

--- a/R/utils.R
+++ b/R/utils.R
@@ -712,3 +712,16 @@ empty_to_null <- function(x) {
     x
   }
 }
+
+dir_read_deprecated <- function(file) {
+  if (is.character(file) && file_is_dir(file)) {
+    lifecycle::deprecate_warn(
+      "0.6.3",
+      I("Reading files through a directory "),
+      details = "Please provide the full path to file to be loaded.",
+      id = "dir_read",
+      env = caller_env(),
+      user_env = caller_env(2)
+    )
+  }
+}

--- a/README.Rmd
+++ b/README.Rmd
@@ -26,45 +26,16 @@ coverage](https://codecov.io/gh/ipums/ipumsr/branch/main/graph/badge.svg)](https
 
 <!-- badges: end -->
 
-ipumsr provides an R interface for handling IPUMS data, allowing users
-to:
+ipumsr provides an R interface for handling
+[IPUMS](https://www.ipums.org) data, allowing users to:
 
 -   Easily read files downloaded from the IPUMS extract system
 
--   Submit requests for data and download files through the IPUMS API
+-   Request data, download files, and get metadata from certain IPUMS
+    collections
 
--   Clean and prepare data using the contextual information contained in
-    the variable-level metadata that is included with many IPUMS files
-
-## What is IPUMS?
-
-[IPUMS](https://www.ipums.org/mission-purpose) is the world's largest
-publicly available individual-level population database, providing
-census and survey data from around the world integrated across time and
-space. IPUMS integration and documentation make it easy to study
-change, conduct comparative research, merge information across data
-types, and analyze individuals within family and community context. Data
-and services are available free of charge.
-
-IPUMS consists of multiple projects, or collections, that provide
-different data products.
-
-- **Microdata** projects distribute data for
-individual survey units, like people or households. 
-- **Aggregate data** projects distribute aggregate statistics calculated from 
-microdata for particular geographic units.
-
-| Project                                                               | Data Type      | Description                                                                                                                                                                                                                                             |
-|-------------|-------------|----------------------------------------------|
-| [IPUMS USA](https://usa.ipums.org/usa/)                               | Microdata      | U.S. Census and American Community Survey microdata (1850-present)                                                                                                                                                                                      |
-| [IPUMS CPS](https://cps.ipums.org/cps/)                               | Microdata      | Current Population Survey microdata including basic monthly surveys and supplements (1962-present)                                                                                                                                                      |
-| [IPUMS International](https://international.ipums.org/international/) | Microdata      | Census microdata covering over 100 countries, contemporary and historical                                                                                                                                                                               |
-| [IPUMS NHGIS](https://www.nhgis.org/)                                 | Aggregate Data | Tabular U.S. Census data and GIS boundary files (1790-present)                                                                                                                                                                                          |
-| [IPUMS IHGIS](https://ihgis.ipums.org/)                               | Aggregate Data | Tabular and GIS data from population, housing, and agricultural censuses around the world                                                                                                                                                               |
-| [IPUMS Time Use](https://timeuse.ipums.org/)                          | Microdata      | Time use microdata from the U.S. (1930-present) and thirteen other countries (1965-present)                                                                                                                                                             |
-| [IPUMS Health Surveys](https://healthsurveys.ipums.org/)              | Microdata      | Microdata from the U.S. [National Health Interview Survey (NHIS)](https://nhis.ipums.org/nhis/) (1963-present) and [Medical Expenditure Panel Survey (MEPS)](https://meps.ipums.org/meps/) (1996-present)                                               |
-| [IPUMS Global Health](https://globalhealth.ipums.org/)                | Microdata      | Health survey microdata for low- and middle-income countries, including harmonized data collections for [Demographic and Health Surveys (DHS)](https://www.idhsdata.org/) and [Performance Monitoring for Action (PMA)](https://pma.ipums.org/) surveys |
-| [IPUMS Higher Ed](https://highered.ipums.org/highered/)               | Microdata      | Survey microdata on the science and engineering workforce in the U.S. from 1993 to 2013                                                                                                                                                                 |
+-   Interpret and process data using the contextual information that is
+    included with many IPUMS files
 
 ## Installation
 
@@ -80,22 +51,75 @@ To install the development version of the package, use
 remotes::install_github("ipums/ipumsr")
 ```
 
+## What is IPUMS?
+
+[IPUMS](https://www.ipums.org/mission-purpose) is the world's largest
+publicly available population database, providing census and survey data
+from around the world integrated across time and space. IPUMS
+integration and documentation make it easy to study change, conduct
+comparative research, merge information across data types, and analyze
+individuals within family and community context. Data and services are
+available free of charge.
+
+IPUMS consists of multiple projects, or collections, that provide
+different data products.
+
+-   **Microdata** projects distribute data for individual survey units,
+    like people or households.
+-   **Aggregate data** projects distribute summary tables of aggregate
+    statistics for particular geographic units along with corresponding
+    GIS mapping files.
+
+ipumsr supports different levels of functionality for each IPUMS project:
+
+| Project / Collection                                                  | Data Type      | Description                                                                                                                                                                                                                                             | Read Data Extracts | Request & Download Data | Get Metadata |
+|:----------------------------------------------------------------------|:---------------|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:-------------------|:------------------------|:-------------|
+| [IPUMS USA](https://usa.ipums.org/usa/)                               | Microdata      | U.S. Census and American Community Survey microdata (1850-present)                                                                                                                                                                                      | X                  | X                       |              |
+| [IPUMS CPS](https://cps.ipums.org/cps/)                               | Microdata      | Current Population Survey microdata including basic monthly surveys and supplements (1962-present)                                                                                                                                                      | X                  | X                       |              |
+| [IPUMS International](https://international.ipums.org/international/) | Microdata      | Census microdata covering over 100 countries, contemporary and historical                                                                                                                                                                               | X                  | X                       |              |
+| [IPUMS NHGIS](https://www.nhgis.org/)                                 | Aggregate Data | Tabular U.S. Census data and GIS mapping files (1790-present)                                                                                                                                                                                           | X                  | X                       | X            |
+| [IPUMS IHGIS](https://ihgis.ipums.org/)                               | Aggregate Data | Tabular and GIS data from population, housing, and agricultural censuses around the world                                                                                                                                                               |                    |                         |              |
+| [IPUMS Time Use](https://timeuse.ipums.org/)                          | Microdata      | Time use microdata from the U.S. (1930-present) and thirteen other countries (1965-present)                                                                                                                                                             | X                  |                         |              |
+| [IPUMS Health Surveys](https://healthsurveys.ipums.org/)              | Microdata      | Microdata from the U.S. [National Health Interview Survey (NHIS)](https://nhis.ipums.org/nhis/) (1963-present) and [Medical Expenditure Panel Survey (MEPS)](https://meps.ipums.org/meps/) (1996-present)                                               | X                  |                         |              |
+| [IPUMS Global Health](https://globalhealth.ipums.org/)                | Microdata      | Health survey microdata for low- and middle-income countries, including harmonized data collections for [Demographic and Health Surveys (DHS)](https://www.idhsdata.org/) and [Performance Monitoring for Action (PMA)](https://pma.ipums.org/) surveys | X                  |                         |              |
+| [IPUMS Higher Ed](https://highered.ipums.org/highered/)               | Microdata      | Survey microdata on the science and engineering workforce in the U.S. from 1993 to 2013                                                                                                                                                                 | X                  |                         |              |
+
+ipumsr uses the [IPUMS API](https://developer.ipums.org/) to submit data
+requests, download data extracts, and get metadata, so the scope of
+ipumsr functionality generally corresponds to the [available API
+functionality](https://developer.ipums.org/docs/v2/apiprogram/apis/). As
+the IPUMS team extends the API to support more functionality for more
+projects, we aim to extend ipumsr capabilities accordingly.
+
 ## Getting started
 
-If you're new to IPUMS data, see the 
-[general introduction](https://tech.popdata.org/ipumsr/articles/ipums.html).
+If you're new to IPUMS data, learn more about what's available through
+the [IPUMS Projects Overview](https://www.ipums.org/overview).
 
-To learn about obtaining IPUMS data via the IPUMS API, see the 
-[IPUMS API 
-introduction](https://tech.popdata.org/ipumsr/articles/ipums-api.html)
+For an overview of how to find, request, download, and read IPUMS data
+into R, see [IPUMS Data and
+R](https://tech.popdata.org/ipumsr/articles/ipums.html).
 
-Additional demonstrations are also available on the
-[package website](https://tech.popdata.org/ipumsr/articles/). You can access
-them through the **articles** tab or by using the `vignette()` function in R
-(e.g. `vignette("ipums-read", package = "ipumsr")`).
+To learn how ipumsr interfaces with the IPUMS extract system via the
+IPUMS API, see the [Introduction to the IPUMS API for R
+Users](https://tech.popdata.org/ipumsr/articles/ipums-api.html).
 
-The [IPUMS support website](https://www.ipums.org/support/exercises)
-also houses many project-specific exercises.
+Additional demonstration vignettes are also available as
+[Articles](https://tech.popdata.org/ipumsr/articles/) on the package
+website or by using the `vignette()` function in R (e.g.
+`vignette("ipums-read", package = "ipumsr")`). These include vignettes
+for accessing
+[microdata](https://tech.popdata.org/ipumsr/articles/ipums-api-micro.html)
+and [NHGIS data and
+metadata](https://tech.popdata.org/ipumsr/articles/ipums-api-nhgis.html)
+via the API.
+
+The [IPUMS support website](https://www.ipums.org/support) also houses
+many project-specific R-based [training
+exercises](https://www.ipums.org/support/exercises). (As of September
+2023, these exercises have not yet been updated to incorporate the major
+API data and metadata access capabilities added to ipumsr in version
+0.6.0.)
 
 ## Related work
 

--- a/README.md
+++ b/README.md
@@ -15,45 +15,16 @@ coverage](https://codecov.io/gh/ipums/ipumsr/branch/main/graph/badge.svg)](https
 
 <!-- badges: end -->
 
-ipumsr provides an R interface for handling IPUMS data, allowing users
-to:
+ipumsr provides an R interface for handling
+[IPUMS](https://www.ipums.org) data, allowing users to:
 
 - Easily read files downloaded from the IPUMS extract system
 
-- Submit requests for data and download files through the IPUMS API
+- Request data, download files, and get metadata from certain IPUMS
+  collections
 
-- Clean and prepare data using the contextual information contained in
-  the variable-level metadata that is included with many IPUMS files
-
-## What is IPUMS?
-
-[IPUMS](https://www.ipums.org/mission-purpose) is the world’s largest
-publicly available individual-level population database, providing
-census and survey data from around the world integrated across time and
-space. IPUMS integration and documentation make it easy to study change,
-conduct comparative research, merge information across data types, and
-analyze individuals within family and community context. Data and
-services are available free of charge.
-
-IPUMS consists of multiple projects, or collections, that provide
-different data products.
-
-- **Microdata** projects distribute data for individual survey units,
-  like people or households.
-- **Aggregate data** projects distribute aggregate statistics calculated
-  from microdata for particular geographic units.
-
-| Project                                                               | Data Type      | Description                                                                                                                                                                                                                                             |
-|-----------------------------------------------------------------------|----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| [IPUMS USA](https://usa.ipums.org/usa/)                               | Microdata      | U.S. Census and American Community Survey microdata (1850-present)                                                                                                                                                                                      |
-| [IPUMS CPS](https://cps.ipums.org/cps/)                               | Microdata      | Current Population Survey microdata including basic monthly surveys and supplements (1962-present)                                                                                                                                                      |
-| [IPUMS International](https://international.ipums.org/international/) | Microdata      | Census microdata covering over 100 countries, contemporary and historical                                                                                                                                                                               |
-| [IPUMS NHGIS](https://www.nhgis.org/)                                 | Aggregate Data | Tabular U.S. Census data and GIS boundary files (1790-present)                                                                                                                                                                                          |
-| [IPUMS IHGIS](https://ihgis.ipums.org/)                               | Aggregate Data | Tabular and GIS data from population, housing, and agricultural censuses around the world                                                                                                                                                               |
-| [IPUMS Time Use](https://timeuse.ipums.org/)                          | Microdata      | Time use microdata from the U.S. (1930-present) and thirteen other countries (1965-present)                                                                                                                                                             |
-| [IPUMS Health Surveys](https://healthsurveys.ipums.org/)              | Microdata      | Microdata from the U.S. [National Health Interview Survey (NHIS)](https://nhis.ipums.org/nhis/) (1963-present) and [Medical Expenditure Panel Survey (MEPS)](https://meps.ipums.org/meps/) (1996-present)                                               |
-| [IPUMS Global Health](https://globalhealth.ipums.org/)                | Microdata      | Health survey microdata for low- and middle-income countries, including harmonized data collections for [Demographic and Health Surveys (DHS)](https://www.idhsdata.org/) and [Performance Monitoring for Action (PMA)](https://pma.ipums.org/) surveys |
-| [IPUMS Higher Ed](https://highered.ipums.org/highered/)               | Microdata      | Survey microdata on the science and engineering workforce in the U.S. from 1993 to 2013                                                                                                                                                                 |
+- Interpret and process data using the contextual information that is
+  included with many IPUMS files
 
 ## Installation
 
@@ -69,22 +40,76 @@ To install the development version of the package, use
 remotes::install_github("ipums/ipumsr")
 ```
 
+## What is IPUMS?
+
+[IPUMS](https://www.ipums.org/mission-purpose) is the world’s largest
+publicly available population database, providing census and survey data
+from around the world integrated across time and space. IPUMS
+integration and documentation make it easy to study change, conduct
+comparative research, merge information across data types, and analyze
+individuals within family and community context. Data and services are
+available free of charge.
+
+IPUMS consists of multiple projects, or collections, that provide
+different data products.
+
+- **Microdata** projects distribute data for individual survey units,
+  like people or households.
+- **Aggregate data** projects distribute summary tables of aggregate
+  statistics for particular geographic units along with corresponding
+  GIS mapping files.
+
+ipumsr supports different levels of functionality for each IPUMS
+project:
+
+| Project / Collection                                                  | Data Type      | Description                                                                                                                                                                                                                                             | Read Data Extracts | Request & Download Data | Get Metadata |
+|:----------------------------------------------------------------------|:---------------|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:-------------------|:------------------------|:-------------|
+| [IPUMS USA](https://usa.ipums.org/usa/)                               | Microdata      | U.S. Census and American Community Survey microdata (1850-present)                                                                                                                                                                                      | X                  | X                       |              |
+| [IPUMS CPS](https://cps.ipums.org/cps/)                               | Microdata      | Current Population Survey microdata including basic monthly surveys and supplements (1962-present)                                                                                                                                                      | X                  | X                       |              |
+| [IPUMS International](https://international.ipums.org/international/) | Microdata      | Census microdata covering over 100 countries, contemporary and historical                                                                                                                                                                               | X                  | X                       |              |
+| [IPUMS NHGIS](https://www.nhgis.org/)                                 | Aggregate Data | Tabular U.S. Census data and GIS mapping files (1790-present)                                                                                                                                                                                           | X                  | X                       | X            |
+| [IPUMS IHGIS](https://ihgis.ipums.org/)                               | Aggregate Data | Tabular and GIS data from population, housing, and agricultural censuses around the world                                                                                                                                                               |                    |                         |              |
+| [IPUMS Time Use](https://timeuse.ipums.org/)                          | Microdata      | Time use microdata from the U.S. (1930-present) and thirteen other countries (1965-present)                                                                                                                                                             | X                  |                         |              |
+| [IPUMS Health Surveys](https://healthsurveys.ipums.org/)              | Microdata      | Microdata from the U.S. [National Health Interview Survey (NHIS)](https://nhis.ipums.org/nhis/) (1963-present) and [Medical Expenditure Panel Survey (MEPS)](https://meps.ipums.org/meps/) (1996-present)                                               | X                  |                         |              |
+| [IPUMS Global Health](https://globalhealth.ipums.org/)                | Microdata      | Health survey microdata for low- and middle-income countries, including harmonized data collections for [Demographic and Health Surveys (DHS)](https://www.idhsdata.org/) and [Performance Monitoring for Action (PMA)](https://pma.ipums.org/) surveys | X                  |                         |              |
+| [IPUMS Higher Ed](https://highered.ipums.org/highered/)               | Microdata      | Survey microdata on the science and engineering workforce in the U.S. from 1993 to 2013                                                                                                                                                                 | X                  |                         |              |
+
+ipumsr uses the [IPUMS API](https://developer.ipums.org/) to submit data
+requests, download data extracts, and get metadata, so the scope of
+ipumsr functionality generally corresponds to the [available API
+functionality](https://developer.ipums.org/docs/v2/apiprogram/apis/). As
+the IPUMS team extends the API to support more functionality for more
+projects, we aim to extend ipumsr capabilities accordingly.
+
 ## Getting started
 
-If you’re new to IPUMS data, see the [general
-introduction](https://tech.popdata.org/ipumsr/articles/ipums.html).
+If you’re new to IPUMS data, learn more about what’s available through
+the [IPUMS Projects Overview](https://www.ipums.org/overview).
 
-To learn about obtaining IPUMS data via the IPUMS API, see the [IPUMS
-API
-introduction](https://tech.popdata.org/ipumsr/articles/ipums-api.html)
+For an overview of how to find, request, download, and read IPUMS data
+into R, see [IPUMS Data and
+R](https://tech.popdata.org/ipumsr/articles/ipums.html).
 
-Additional demonstrations are also available on the [package
-website](https://tech.popdata.org/ipumsr/articles/). You can access them
-through the **articles** tab or by using the `vignette()` function in R
-(e.g. `vignette("ipums-read", package = "ipumsr")`).
+To learn how ipumsr interfaces with the IPUMS extract system via the
+IPUMS API, see the [Introduction to the IPUMS API for R
+Users](https://tech.popdata.org/ipumsr/articles/ipums-api.html).
 
-The [IPUMS support website](https://www.ipums.org/support/exercises)
-also houses many project-specific exercises.
+Additional demonstration vignettes are also available as
+[Articles](https://tech.popdata.org/ipumsr/articles/) on the package
+website or by using the `vignette()` function in R (e.g.
+`vignette("ipums-read", package = "ipumsr")`). These include vignettes
+for accessing
+[microdata](https://tech.popdata.org/ipumsr/articles/ipums-api-micro.html)
+and [NHGIS data and
+metadata](https://tech.popdata.org/ipumsr/articles/ipums-api-nhgis.html)
+via the API.
+
+The [IPUMS support website](https://www.ipums.org/support) also houses
+many project-specific R-based [training
+exercises](https://www.ipums.org/support/exercises). (As of September
+2023, these exercises have not yet been updated to incorporate the major
+API data and metadata access capabilities added to ipumsr in version
+0.6.0.)
 
 ## Related work
 

--- a/man/ipums_list_files.Rd
+++ b/man/ipums_list_files.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/list_files.R
 \name{ipums_list_files}
 \alias{ipums_list_files}
-\title{List files contained within an IPUMS extract}
+\title{List files contained within a zipped IPUMS extract}
 \usage{
 ipums_list_files(
   file,
@@ -14,8 +14,8 @@ ipums_list_files(
 )
 }
 \arguments{
-\item{file}{Path to a .zip archive or directory containing the IPUMS extract
-to be examined.}
+\item{file}{Path to a .zip archive containing the IPUMS extract to be
+examined.}
 
 \item{file_select}{If the path in \code{file} contains multiple files, a
 \link[=selection_language]{tidyselect selection} identifying the files to be
@@ -40,8 +40,7 @@ A \code{\link[tibble:tbl_df-class]{tibble}} containing the types and names of
 the available files.
 }
 \description{
-Identify the files that can be read from an IPUMS extract, whether its
-files are stored in a .zip archive or a directory.
+Identify the files that can be read from an IPUMS extract.
 }
 \examples{
 nhgis_file <- ipums_example("nhgis0712_csv.zip")

--- a/man/read_ipums_ddi.Rd
+++ b/man/read_ipums_ddi.Rd
@@ -14,8 +14,8 @@ read_ipums_ddi(
 }
 \arguments{
 \item{ddi_file}{Path to a DDI .xml file downloaded from
-\href{https://www.ipums.org/}{IPUMS} or a .zip archive or directory containing
-the .xml file. See \emph{Downloading IPUMS files} below.}
+\href{https://www.ipums.org/}{IPUMS} or a .zip archive containing the .xml file.
+See \emph{Downloading IPUMS files} below.}
 
 \item{file_select}{If \code{ddi_file} is a .zip archive or directory that contains
 multiple .xml files, an expression identifying the file to read.

--- a/man/read_ipums_ddi.Rd
+++ b/man/read_ipums_ddi.Rd
@@ -7,27 +7,21 @@ file}
 \usage{
 read_ipums_ddi(
   ddi_file,
-  file_select = NULL,
   lower_vars = FALSE,
+  file_select = deprecated(),
   data_layer = deprecated()
 )
 }
 \arguments{
 \item{ddi_file}{Path to a DDI .xml file downloaded from
-\href{https://www.ipums.org/}{IPUMS} or a .zip archive containing the .xml file.
-See \emph{Downloading IPUMS files} below.}
-
-\item{file_select}{If \code{ddi_file} is a .zip archive or directory that contains
-multiple .xml files, an expression identifying the file to read.
-Accepts a character string specifying the file name, a
-\link[=selection_language]{tidyselect selection}, or an index position.
-Ignored if \code{ddi_file} is the path to a single .xml file.}
+\href{https://www.ipums.org/}{IPUMS}. See \emph{Downloading IPUMS files} below.}
 
 \item{lower_vars}{Logical indicating whether to convert variable names to
 lowercase. Defaults to \code{FALSE} for consistency with IPUMS conventions.}
 
-\item{data_layer}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Please use \code{file_select}
-instead.}
+\item{data_layer, file_select}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Reading
+DDI files contained in a .zip archive has been deprecated. Please provide
+the full path to the .xml file to be loaded in \code{ddi_file}.}
 }
 \value{
 An \link{ipums_ddi} object with metadata information.

--- a/man/read_ipums_sf.Rd
+++ b/man/read_ipums_sf.Rd
@@ -16,10 +16,10 @@ read_ipums_sf(
 )
 }
 \arguments{
-\item{shape_file}{Path to a single .shp file, or a .zip archive or
-directory containing at least one .shp file. See Details section.}
+\item{shape_file}{Path to a single .shp file or a .zip archive
+containing at least one .shp file. See Details section.}
 
-\item{file_select}{If \code{shape_file} is a .zip archive or directory that
+\item{file_select}{If \code{shape_file} is a .zip archive that
 contains multiple files, an expression identifying the files to load.
 Accepts a character string specifying the
 file name, a \link[=selection_language]{tidyselect selection}, or index

--- a/man/read_ipums_sp.Rd
+++ b/man/read_ipums_sp.Rd
@@ -15,8 +15,8 @@ read_ipums_sp(
 )
 }
 \arguments{
-\item{shape_file}{Path to a single .shp file, or a .zip archive or
-directory containing at least one .shp file. See Details section.}
+\item{shape_file}{Path to a single .shp file or a .zip archive
+containing at least one .shp file. See Details section.}
 
 \item{shape_layer}{If \code{shape_file} contains multiple files, an expression
 identifying the files to load. Accepts a character string specifying the

--- a/man/read_nhgis.Rd
+++ b/man/read_nhgis.Rd
@@ -19,10 +19,10 @@ read_nhgis(
 )
 }
 \arguments{
-\item{data_file}{Path to a data file, a .zip archive from an NHGIS
-extract, or a directory containing the data file.}
+\item{data_file}{Path to a .zip archive containing an NHGIS extract or
+a single file from an NHGIS extract.}
 
-\item{file_select}{If \code{data_file} is a .zip archive or directory that
+\item{file_select}{If \code{data_file} is a .zip archive that
 contains multiple files, an expression identifying the file to load.
 Accepts a character vector specifying the
 file name, a \link[=selection_language]{tidyselect selection}, or an index
@@ -62,8 +62,8 @@ column types. Will never use more than the number of lines read.}
 the provided \code{data_file}. The .do file contains the parsing instructions
 for the data file.
 
-By default, looks in the same directory as \code{data_file} for a .do
-file with the same name. See Details section below.}
+By default, looks in the same path as \code{data_file} for
+a .do file with the same name. See Details section below.}
 
 \item{var_attrs}{Variable attributes to add from the codebook (.txt) file
 included in the extract. Defaults to all available attributes.

--- a/tests/testthat/test_deprec_dir_read.R
+++ b/tests/testthat/test_deprec_dir_read.R
@@ -39,7 +39,7 @@ test_that("Reading through directory is deprecated", {
     "Reading files through a directory"
   )
   lifecycle::expect_deprecated(
-    try(read_nhgis_sf(test_path), silent = TRUE),
+    try(read_ipums_sf(test_path), silent = TRUE),
     "Reading files through a directory"
   )
 })

--- a/tests/testthat/test_deprec_dir_read.R
+++ b/tests/testthat/test_deprec_dir_read.R
@@ -1,0 +1,55 @@
+test_that("Reading through directory is deprecated", {
+  test_path <- vcr::vcr_test_path("fixtures")
+
+  lifecycle::expect_deprecated(
+    x <- read_ipums_ddi(test_path, file_select = 1),
+    "Reading files through a directory"
+  )
+
+  # Confirm that we can still read using `file_select` for now
+  expect_s3_class(x, "ipums_ddi")
+  expect_s3_class(
+    suppressWarnings(
+      read_nhgis(
+        vcr::vcr_test_path("fixtures", "nhgis_unzipped"),
+        file_select = 1
+      )
+    ),
+    "tbl_df"
+  )
+
+  # Still should get correct errors
+  expect_error(
+    suppressWarnings(read_ipums_ddi(test_path)),
+    "Multiple files found"
+  )
+  expect_error(
+    suppressWarnings(read_nhgis(test_path)),
+    "No .csv or .dat files found"
+  )
+
+  # Suppress file not found errors, which we expect but are not of interest
+  # for these tests
+  lifecycle::expect_deprecated(
+    try(read_nhgis_codebook(test_path), silent = TRUE),
+    "Reading files through a directory"
+  )
+  lifecycle::expect_deprecated(
+    try(read_nhgis(test_path), silent = TRUE),
+    "Reading files through a directory"
+  )
+  lifecycle::expect_deprecated(
+    try(read_nhgis_sf(test_path), silent = TRUE),
+    "Reading files through a directory"
+  )
+})
+
+test_that("Get correct file path when loading from directory", {
+  test_path <- vcr::vcr_test_path("fixtures")
+
+  lifecycle::expect_deprecated(
+    x <- read_ipums_ddi(test_path, file_select = 1)
+  )
+
+  expect_equal(x$file_path, test_path)
+})

--- a/tests/testthat/test_micro.R
+++ b/tests/testthat/test_micro.R
@@ -126,6 +126,13 @@ test_that("Can't read Rectangular into list format", {
   )
 })
 
+test_that("Can read microdata from an `ipums_ddi` object", {
+  x1 <- read_ipums_micro(ipums_example("cps_00157.xml"))
+  x2 <- read_ipums_micro(read_ipums_ddi(ipums_example("cps_00157.xml")))
+
+  expect_identical(x1, x2)
+})
+
 test_that("Arguments n_max and vars work", {
   cps <- read_ipums_micro(
     ipums_example("cps_00159.xml"),

--- a/tests/testthat/test_micro.R
+++ b/tests/testthat/test_micro.R
@@ -161,7 +161,7 @@ test_that("Setting argument var_attrs to NULL works", {
   expect_true(all(no_var_attrs))
 })
 
-test_that("Informative error when no ddi file", {
+test_that("Informative errors when improper ddi file", {
   expect_error(
     read_ipums_micro("FAKE_FILE.xml"),
     "Could not find file .+/FAKE_FILE.xml`"
@@ -169,6 +169,26 @@ test_that("Informative error when no ddi file", {
   expect_error(
     read_ipums_micro("C:/FAKE_FOLDER/FAKE_FILE.xml"),
     "Could not find file `C:/FAKE_FOLDER/FAKE_FILE.xml`"
+  )
+
+  # Try to read through a directory/zip:
+  vcr_dir <- vcr::vcr_test_path("fixtures")
+
+  expect_error(
+    read_ipums_micro(vcr_dir),
+    "Expected `ddi` to be an `ipums_ddi` object or the path"
+  )
+  expect_error(
+    read_ipums_micro_list(vcr_dir),
+    "Expected `ddi` to be an `ipums_ddi` object or the path"
+  )
+  expect_error(
+    read_ipums_micro_yield(file.path(vcr_dir, "zipped_ddi.zip")),
+    "Expected `ddi` to be an `ipums_ddi` object or the path"
+  )
+  expect_error(
+    read_ipums_micro_chunked(file.path(vcr_dir, "zipped_ddi.zip")),
+    "Expected `ddi` to be an `ipums_ddi` object or the path"
   )
 })
 

--- a/tests/testthat/test_nhgis.R
+++ b/tests/testthat/test_nhgis.R
@@ -415,53 +415,16 @@ test_that("Can read NHGIS codebook", {
   )
 })
 
-test_that("Can read certain unzipped structures", {
-  file_dir <- vcr::vcr_test_path("fixtures", "nhgis_unzipped")
+test_that("Can read unzipped NHGIS files", {
+  test_path <- vcr::vcr_test_path("fixtures", "nhgis_unzipped")
 
-  sps_tmpfile <- file.path(file_dir, "test.sps")
-  csv_tmpfile1 <- file.path(file_dir, "test1.csv")
-  csv_tmpfile2 <- file.path(file_dir, "test2.csv")
-
-  # Reading a directory produces expected file count errors
-  expect_error(
-    read_nhgis("."),
-    "No .csv or .dat files found"
-  )
-  expect_error(
-    read_nhgis(file_dir),
-    "Multiple files found"
+  x1 <- suppressWarnings(read_nhgis(test_path, file_select = 1))
+  x2 <- read_nhgis(
+    file.path(test_path, "test1.csv"),
+    var_attrs = NULL,
+    verbose = FALSE
   )
 
-  # We did not write a codebook, so `read_nhgis` should be unable
-  # to find the codebook in this case
-  expect_warning(
-    x1 <- read_nhgis(file_dir, file_select = 1),
-    "Unable to read codebook"
-  )
-
-  # Direct file path should work, of course
-  expect_message(
-    x2 <- read_nhgis(file.path(file_dir, "test1.csv"), var_attrs = NULL),
-    "Use of data from NHGIS"
-  )
   expect_equal(x1$a, "b")
   expect_equal(x1, x2)
-
-  # Using `file_select` should be identical to reading direct file path
-  expect_equal(
-    read_nhgis(file_dir, file_select = 1, var_attrs = NULL),
-    x1
-  )
-
-  # Direct data file errors if mismatched extension
-  expect_error(
-    read_nhgis_fwf(csv_tmpfile1),
-    "Expected `file` to match extension"
-  )
-
-  # Reading a direct data file should ignore data layer
-  expect_equal(
-    suppressWarnings(read_nhgis(csv_tmpfile1, file_select = 3)),
-    x2
-  )
 })

--- a/tests/testthat/test_read_ddi.R
+++ b/tests/testthat/test_read_ddi.R
@@ -14,9 +14,12 @@ test_that("We ignore layer selection for direct .xml files", {
   ddi1 <- read_ipums_ddi(
     file.path(vcr::vcr_test_path("fixtures"), "mtus_00002.xml")
   )
-  ddi2 <- read_ipums_ddi(
-    file.path(vcr::vcr_test_path("fixtures"), "mtus_00002.xml"),
-    file_select = 4
+  lifecycle::expect_deprecated(
+    ddi2 <- read_ipums_ddi(
+      file.path(vcr::vcr_test_path("fixtures"), "mtus_00002.xml"),
+      file_select = 4
+    ),
+    "The `file_select` argument"
   )
   expect_identical(ddi1, ddi2)
 })
@@ -24,8 +27,13 @@ test_that("We ignore layer selection for direct .xml files", {
 test_that("Can read ddi from zip archives", {
   zipped_ddi <- file.path(vcr::vcr_test_path("fixtures"), "zipped_ddi.zip")
 
+  lifecycle::expect_deprecated(
+    try(read_ipums_ddi(zipped_ddi), silent = TRUE),
+    "Reading DDI files through a zip archive"
+  )
+
   expect_error(
-    read_ipums_ddi(zipped_ddi),
+    suppressWarnings(read_ipums_ddi(zipped_ddi)),
     "Multiple files found"
   )
 

--- a/tests/testthat/test_read_ddi.R
+++ b/tests/testthat/test_read_ddi.R
@@ -52,8 +52,3 @@ test_that("Can read ddi from zip archives", {
     read_ipums_ddi(ipums_example("cps_00159.xml"))$var_info
   )
 })
-
-test_that("Get correct file path when loading from directory", {
-  x <- read_ipums_ddi(vcr::vcr_test_path("fixtures"), file_select = 1)
-  expect_equal(x$file_path, vcr::vcr_test_path("fixtures"))
-})

--- a/tests/testthat/test_read_ddi.R
+++ b/tests/testthat/test_read_ddi.R
@@ -52,3 +52,8 @@ test_that("Can read ddi from zip archives", {
     read_ipums_ddi(ipums_example("cps_00159.xml"))$var_info
   )
 })
+
+test_that("Get correct file path when loading from directory", {
+  x <- read_ipums_ddi(vcr::vcr_test_path("fixtures"), file_select = 1)
+  expect_equal(x$file_path, vcr::vcr_test_path("fixtures"))
+})

--- a/vignettes/ipums-api-nhgis.Rmd
+++ b/vignettes/ipums-api-nhgis.Rmd
@@ -82,19 +82,20 @@ get_truncated_metadata <- function(collection,
 }
 ```
 
-This vignette details the options available for requesting IPUMS NHGIS data 
-via the IPUMS API.
+This vignette details the options available for requesting IPUMS NHGIS
+data and metadata via the IPUMS API.
 
-If you haven't yet learned the basics of the IPUMS API workflow, you may want
-to start with the [IPUMS API introduction](ipums-api.html). The code below
-assumes you have registered and set up your API key as described there.
+If you haven't yet learned the basics of the IPUMS API workflow, you may
+want to start with the [IPUMS API introduction](ipums-api.html). The
+code below assumes you have registered and set up your API key as
+described there.
 
-In addition to NHGIS, the IPUMS API also supports several microdata projects.
-For details about obtaining IPUMS microdata using ipumsr, see
+In addition to NHGIS, the IPUMS API also supports several microdata
+projects. For details about obtaining IPUMS microdata using ipumsr, see
 the [microdata-specific vignette](ipums-api-micro.html).
 
-Before getting started, we'll load ipumsr and some helpful packages for this 
-demo:
+Before getting started, we'll load ipumsr and some helpful packages for
+this demo:
 
 ```{r, message=FALSE}
 library(ipumsr)
@@ -104,32 +105,37 @@ library(purrr)
 
 ## Basic IPUMS NHGIS concepts
 
-IPUMS NHGIS supports 3 main types of data products: datasets, time series 
-tables, and shapefiles.
+IPUMS NHGIS supports 3 main types of data products: datasets, time
+series tables, and shapefiles.
 
-* A _dataset_ contains a collection of _data tables_ that each correspond to a
-particular tabulated summary statistic. A dataset is distinguished by the years, 
-geographic levels, and topics that it covers. For instance, 2021 1-year data 
-from the American Community Survey (ACS) is encapsulated in a single dataset. In
-other cases, a single census product will be split into multiple datasets.
+-   A *dataset* contains a collection of *data tables* that each
+    correspond to a particular tabulated summary statistic. A dataset is
+    distinguished by the years, geographic levels, and topics that it
+    covers. For instance, 2021 1-year data from the American Community
+    Survey (ACS) is encapsulated in a single dataset. In other cases, a
+    single census product will be split into multiple datasets.
 
-* A _time series table_ is a longitudinal data source that links comparable 
-statistics from multiple U.S. censuses in a single bundle. A table is 
-comprised of one or more related time series, each of which describes a single
-summary statistic measured at multiple times for a given geographic level.
+-   A *time series table* is a longitudinal data source that links
+    comparable statistics from multiple U.S. censuses in a single
+    bundle. A table is comprised of one or more related time series,
+    each of which describes a single summary statistic measured at
+    multiple times for a given geographic level.
 
-* A _shapefile_ (or _GIS file_) contains geographic data for a given 
-geographic level and year. Typically, these files are composed of polygon
-geometries containing the boundaries of census reporting areas.
+-   A *shapefile* (or *GIS file*) contains geographic data for a given
+    geographic level and year. Typically, these files are composed of
+    polygon geometries containing the boundaries of census reporting
+    areas.
 
 ## IPUMS NHGIS metadata
 
-Of course, to make a request for any of these data sources, we have to know 
-the codes that the API uses to refer to them. Fortunately, we can browse the 
-metadata for all available IPUMS NHGIS data sources with `get_metadata_nhgis()`. 
+Of course, to make a request for any of these data sources, we have to
+know the codes that the API uses to refer to them. Fortunately, we can
+browse the metadata for all available IPUMS NHGIS data sources with
+`get_metadata_nhgis()`.
 
-Users can view summary metadata for all available data sources of a given
-data type, or detailed metadata for a specific data source by name.
+Users can view summary metadata for all available data sources of a
+given data type, or detailed metadata for a specific data source by
+name.
 
 ### Summary metadata
 
@@ -137,9 +143,9 @@ data type, or detailed metadata for a specific data source by name.
 insert_cassette("nhgis-metadata-summary")
 ```
 
-To see a summary of all available sources for a given data product type, 
-use the `type` argument. This returns a data frame containing the available
-datasets, data tables, time series tables, or shapefiles.
+To see a summary of all available sources for a given data product type,
+use the `type` argument. This returns a data frame containing the
+available datasets, data tables, time series tables, or shapefiles.
 
 ```{r}
 ds <- get_metadata_nhgis(type = "datasets")
@@ -147,10 +153,10 @@ ds <- get_metadata_nhgis(type = "datasets")
 head(ds)
 ```
 
-We can use basic functions from [dplyr](https://dplyr.tidyverse.org/) to 
-filter the metadata to those records of
-interest. For instance, if we wanted to find all the data sources related to
-agriculture from the 1900 Census, we could filter on `group` and `description`:
+We can use basic functions from [dplyr](https://dplyr.tidyverse.org/) to
+filter the metadata to those records of interest. For instance, if we
+wanted to find all the data sources related to agriculture from the 1900
+Census, we could filter on `group` and `description`:
 
 ```{r}
 ds %>% 
@@ -160,9 +166,9 @@ ds %>%
   )
 ```
 
-The values listed in the `name` column correspond to the code that you would 
-use to request that dataset when creating an extract definition to be submitted 
-to the IPUMS API.
+The values listed in the `name` column correspond to the code that you
+would use to request that dataset when creating an extract definition to
+be submitted to the IPUMS API.
 
 Similarly, for time series tables:
 
@@ -179,15 +185,16 @@ tst <- get_truncated_metadata("nhgis", "time_series_tables")
 tst <- get_metadata_nhgis("time_series_tables")
 ```
 
-While some of the metadata fields are consistent across different data types,
-some, like `geographic_integration`, are specific to time series tables:
+While some of the metadata fields are consistent across different data
+types, some, like `geographic_integration`, are specific to time series
+tables:
 
 ```{r}
 head(tst)
 ```
 
-Note that for time series tables, some metadata fields are stored in list
-columns, where each entry is itself a data frame:
+Note that for time series tables, some metadata fields are stored in
+list columns, where each entry is itself a data frame:
 
 ```{r}
 tst$years[[1]]
@@ -195,9 +202,9 @@ tst$years[[1]]
 tst$geog_levels[[1]]
 ```
 
-To filter on these columns, we can use `map_lgl()` from 
-[purrr](https://purrr.tidyverse.org/). For instance, to find all time series 
-tables that include data from a particular year:
+To filter on these columns, we can use `map_lgl()` from
+[purrr](https://purrr.tidyverse.org/). For instance, to find all time
+series tables that include data from a particular year:
 
 ```{r}
 # Iterate over each `years` entry, identifying whether that entry
@@ -206,8 +213,9 @@ tst %>%
   filter(map_lgl(years, ~ "1840" %in% .x$name))
 ```
 
-For more details on working with nested data frames, see the documentation for
-[dplyr](https://dplyr.tidyverse.org/) and [purrr](https://purrr.tidyverse.org/).
+For more details on working with nested data frames, see the
+documentation for [dplyr](https://dplyr.tidyverse.org/) and
+[purrr](https://purrr.tidyverse.org/).
 
 ```{r, echo=FALSE, results="hide", message=FALSE}
 eject_cassette("nhgis-metadata-summary")
@@ -219,17 +227,17 @@ eject_cassette("nhgis-metadata-summary")
 insert_cassette("nhgis-metadata-detailed")
 ```
 
-Once we have identified a data source of interest, we can find out more about
-its detailed options by providing its name to the corresponding argument of
-`get_metadata_nhgis()`:
+Once we have identified a data source of interest, we can find out more
+about its detailed options by providing its name to the corresponding
+argument of `get_metadata_nhgis()`:
 
 ```{r}
 cAg_meta <- get_metadata_nhgis(dataset = "1900_cAg")
 ```
 
-This provides a comprehensive list of the possible specifications for the input
-data source. For instance, for the 1900_cAg dataset, we have 66 tables to
-choose from, and 3 possible geographic levels:
+This provides a comprehensive list of the possible specifications for
+the input data source. For instance, for the 1900_cAg dataset, we have
+66 tables to choose from, and 3 possible geographic levels:
 
 ```{r}
 cAg_meta$data_tables
@@ -237,23 +245,23 @@ cAg_meta$data_tables
 cAg_meta$geog_levels
 ```
 
-You can also get detailed metadata for an individual data table. Since data
-tables belong to specific datasets, both need to be specified to identify a
-data table:
+You can also get detailed metadata for an individual data table. Since
+data tables belong to specific datasets, both need to be specified to
+identify a data table:
 
 ```{r}
 get_metadata_nhgis(dataset = "1900_cAg", data_table = "NT2")
 ```
 
-Note that the `name` element is the one that contains the codes used for 
-interacting with the IPUMS API. The `nhgis_code` element refers to the 
-prefix attached to individual variables in the output data, and the API will 
-throw an error if you use it in an extract definition.
-For more details on interpreting each of the provided metadata elements, see 
-the documentation for `get_metadata_nhgis()`.
+Note that the `name` element is the one that contains the codes used for
+interacting with the IPUMS API. The `nhgis_code` element refers to the
+prefix attached to individual variables in the output data, and the API
+will throw an error if you use it in an extract definition. For more
+details on interpreting each of the provided metadata elements, see the
+documentation for `get_metadata_nhgis()`.
 
-Now that we have identified some of our options, we can go ahead and define
-an extract request to submit to the IPUMS API.
+Now that we have identified some of our options, we can go ahead and
+define an extract request to submit to the IPUMS API.
 
 ```{r, echo=FALSE, results="hide", message=FALSE}
 eject_cassette("nhgis-metadata-detailed")
@@ -261,27 +269,29 @@ eject_cassette("nhgis-metadata-detailed")
 
 ## Defining an IPUMS NHGIS extract request
 
-To create an extract definition containing the specifications for a specific
-set of IPUMS NHGIS data, use `define_extract_nhgis()`.
+To create an extract definition containing the specifications for a
+specific set of IPUMS NHGIS data, use `define_extract_nhgis()`.
 
 When you define an extract request, you can specify the data to be
 included in the extract and indicate the desired format and layout.
 
 ### Basic extract definitions
 
-Let's say we're interested in getting state-level data on the number of 
-farms and their average size from the 1900_cAg dataset that we identified above. 
-As we can see in the metadata, these data are contained in tables NT2 and NT3:
+Let's say we're interested in getting state-level data on the number of
+farms and their average size from the 1900_cAg dataset that we
+identified above. As we can see in the metadata, these data are
+contained in tables NT2 and NT3:
 
 ```{r}
 cAg_meta$data_tables
 ```
 
-To request these data, we need to make an explicit
-_dataset specification_. All datasets must be associated with a selection of
-data tables and geographic levels. We can use the `ds_spec()` helper function
-to specify our selections for these parameters. `ds_spec()` bundles all the selections for a given dataset together into 
-a single object (in this case, a `ds_spec` object):
+To request these data, we need to make an explicit *dataset
+specification*. All datasets must be associated with a selection of data
+tables and geographic levels. We can use the `ds_spec()` helper function
+to specify our selections for these parameters. `ds_spec()` bundles all
+the selections for a given dataset together into a single object (in
+this case, a `ds_spec` object):
 
 ```{r}
 dataset <- ds_spec(
@@ -293,7 +303,8 @@ dataset <- ds_spec(
 str(dataset)
 ```
 
-This dataset specification can then be provided to the extract definition:
+This dataset specification can then be provided to the extract
+definition:
 
 ```{r}
 nhgis_ext <- define_extract_nhgis(
@@ -304,15 +315,15 @@ nhgis_ext <- define_extract_nhgis(
 nhgis_ext
 ```
 
-(Dataset specifications can also include selections for `years` and 
+(Dataset specifications can also include selections for `years` and
 `breakdown_values`, but these are not available for all datasets.)
 
-Similarly, to make a request for time series tables, use the `tst_spec()`
-helper. This makes a `tst_spec` object containing a time series table 
-specification.
+Similarly, to make a request for time series tables, use the
+`tst_spec()` helper. This makes a `tst_spec` object containing a time
+series table specification.
 
-Time series tables do not contain individual data tables, but do require a 
-geographic level selection, and allow an optional selection of years:
+Time series tables do not contain individual data tables, but do require
+a geographic level selection, and allow an optional selection of years:
 
 ```{r}
 define_extract_nhgis(
@@ -325,8 +336,9 @@ define_extract_nhgis(
 )
 ```
 
-An attempt to define an extract that does not have all the required 
-specifications for a given dataset or time series table will throw an error:
+An attempt to define an extract that does not have all the required
+specifications for a given dataset or time series table will throw an
+error:
 
 ```{r, error=TRUE}
 define_extract_nhgis(
@@ -335,13 +347,13 @@ define_extract_nhgis(
 )
 ```
 
-Note that it is still possible to make invalid extract requests 
-(for instance, by requesting a dataset or table that doesn't exist). 
-This kind of issue will be caught upon submission to the API, not upon the
+Note that it is still possible to make invalid extract requests (for
+instance, by requesting a dataset or table that doesn't exist). This
+kind of issue will be caught upon submission to the API, not upon the
 creation of the extract definition.
 
-Shapefiles don't have any additional specification options, and therefore 
-can be requested simply by providing their names:
+Shapefiles don't have any additional specification options, and
+therefore can be requested simply by providing their names:
 
 ```{r}
 define_extract_nhgis(
@@ -352,9 +364,9 @@ define_extract_nhgis(
 
 ### More complicated extract definitions
 
-It's possible to request data for multiple datasets (or time series tables)
-in a single extract definition. To do so, pass a `list` of `ds_spec`
-or `tst_spec` objects in `define_extract_nhgis()`:
+It's possible to request data for multiple datasets (or time series
+tables) in a single extract definition. To do so, pass a `list` of
+`ds_spec` or `tst_spec` objects in `define_extract_nhgis()`:
 
 ```{r}
 define_extract_nhgis(
@@ -367,11 +379,11 @@ define_extract_nhgis(
 )
 ```
 
-For extracts with multiple datasets or time series tables, it may be easier 
-to generate the specifications independently before creating your extract 
-request object. You can quickly create multiple `ds_spec` objects by 
-iterating across the specifications you want to include. Here, we use purrr
-to do so, but you could also use a `for` loop:
+For extracts with multiple datasets or time series tables, it may be
+easier to generate the specifications independently before creating your
+extract request object. You can quickly create multiple `ds_spec`
+objects by iterating across the specifications you want to include.
+Here, we use purrr to do so, but you could also use a `for` loop:
 
 ```{r}
 ds_names <- c("2019_ACS1", "2018_ACS1")
@@ -397,31 +409,32 @@ nhgis_ext <- define_extract_nhgis(
 nhgis_ext
 ```
 
-This workflow also makes it easy to quickly update the specifications in the
-future. For instance, to add the 2017 ACS 1-year data to the extract definition 
-above, you'd only need to add `"2017_ACS1"` to the `ds_names` variable. 
-The iteration would automatically add the selected tables and geog levels for 
-the new dataset. (This workflow works particularly well for ACS datasets, which 
-often have the same data table names across datasets.)
+This workflow also makes it easy to quickly update the specifications in
+the future. For instance, to add the 2017 ACS 1-year data to the extract
+definition above, you'd only need to add `"2017_ACS1"` to the `ds_names`
+variable. The iteration would automatically add the selected tables and
+geog levels for the new dataset. (This workflow works particularly well
+for ACS datasets, which often have the same data table names across
+datasets.)
 
 ### Data layout and file format
 
-IPUMS NHGIS extract definitions also support additional options to modify the 
-layout and format of the extract's resulting data files. 
+IPUMS NHGIS extract definitions also support additional options to
+modify the layout and format of the extract's resulting data files.
 
 For extracts that contain time series tables, the `tst_layout` argument
 indicates how the longitudinal data should be organized.
 
-For extracts that contain datasets with multiple breakdowns
-or data types, use the `breakdown_and_data_type_layout` argument to
-specify a layout . This is most common for data sources that contain both 
+For extracts that contain datasets with multiple breakdowns or data
+types, use the `breakdown_and_data_type_layout` argument to specify a
+layout . This is most common for data sources that contain both
 estimates and margins of error, like the ACS.
 
-File formats can be specified with the `data_format` argument. IPUMS NHGIS
-currently distributes files in csv and fixed-width format.
+File formats can be specified with the `data_format` argument. IPUMS
+NHGIS currently distributes files in csv and fixed-width format.
 
-See the documentation for `define_extract_nhgis()` for more details on 
-these options. 
+See the documentation for `define_extract_nhgis()` for more details on
+these options.
 
 ## Next steps
 
@@ -432,6 +445,6 @@ processing:
 nhgis_ext_submitted <- submit_extract(nhgis_ext)
 ```
 
-The workflow for submitting and monitoring an extract request and downloading
-its files when complete is described in the 
-[IPUMS API introduction](ipums-api.html).
+The workflow for submitting and monitoring an extract request and
+downloading its files when complete is described in the [IPUMS API
+introduction](ipums-api.html).

--- a/vignettes/ipums-api.Rmd
+++ b/vignettes/ipums-api.Rmd
@@ -1,9 +1,9 @@
 ---
-title: "Introduction to the IPUMS API"
+title: "Introduction to the IPUMS API for R Users"
 author: "Institute for Social Research and Data Innovation"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{Introduction to the IPUMS API}
+  %\VignetteIndexEntry{Introduction to the IPUMS API for R Users}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---
@@ -66,24 +66,25 @@ modify_ready_extract_cassette_file <- function(cassette_file_name,
 }
 ```
 
-The IPUMS API provides two asset types, both of which are supported by ipumsr:
+The IPUMS API provides two asset types, both of which are supported by
+ipumsr:
 
 -   **IPUMS extract** endpoints can be used to submit extract requests
-for processing and download completed extract files.
+    for processing and download completed extract files.
 
 -   **IPUMS metadata** endpoints can be used to discover and explore
-available IPUMS data as well as retrieve codes, names, and other
-extract parameters necessary to form extract requests.
+    available IPUMS data as well as retrieve codes, names, and other
+    extract parameters necessary to form extract requests.
 
 Use of the IPUMS API enables the adoption of a programmatic workflow
 that can help users to:
 
 -   Precisely recreate the specifications of previous extract requests,
-making analysis scripts reproducible and self-contained
+    making analysis scripts reproducible and self-contained
 -   Save extract request definitions that can be shared with others
-without violating IPUMS conditions
+    without violating IPUMS conditions
 -   Integrate the extract download process with functions to load data
-into R
+    into R
 -   Quickly identify and explore available IPUMS data sources
 
 The basic workflow for interacting with the IPUMS API is as follows:
@@ -112,9 +113,9 @@ following collections:
 -   IPUMS International
 -   IPUMS NHGIS
 
-Note that this support only includes data available via a
-collection's extract engine. Many collections provide additional data via
-direct download, but these products are not supported by the IPUMS API.
+Note that this support only includes data available via a collection's
+extract engine. Many collections provide additional data via direct
+download, but these products are not supported by the IPUMS API.
 
 IPUMS **metadata** support is currently available via API for the
 following collections:
@@ -146,13 +147,13 @@ can find links to register for each of the API-supported IPUMS
 collections below:
 
 -   [IPUMS
-USA](https://uma.pop.umn.edu/usa/user/new?return_url=https%3A%2F%2Fusa.ipums.org%2Fusa-action%2Fmenu)
+    USA](https://uma.pop.umn.edu/usa/user/new?return_url=https%3A%2F%2Fusa.ipums.org%2Fusa-action%2Fmenu)
 -   [IPUMS
-CPS](https://uma.pop.umn.edu/cps/user/new?return_url=https%3A%2F%2Fcps.ipums.org%2Fcps-action%2Fmenu)
+    CPS](https://uma.pop.umn.edu/cps/user/new?return_url=https%3A%2F%2Fcps.ipums.org%2Fcps-action%2Fmenu)
 -   [IPUMS
-International](https://uma.pop.umn.edu/ipumsi/user/new?return_url=https%3A%2F%2Fipumsi.ipums.org%2Fipumsi-action%2Fmenu)
+    International](https://uma.pop.umn.edu/ipumsi/user/new?return_url=https%3A%2F%2Fipumsi.ipums.org%2Fipumsi-action%2Fmenu)
 -   [IPUMS
-NHGIS](https://uma.pop.umn.edu/nhgis/user/new?return_url=https%3A%2F%2Fnhgis.ipums.org%2Fnhgis-action%2Fmenu)
+    NHGIS](https://uma.pop.umn.edu/nhgis/user/new?return_url=https%3A%2F%2Fnhgis.ipums.org%2Fnhgis-action%2Fmenu)
 
 Once you're registered, you'll be able to [create an API
 key](https://account.ipums.org/api_keys).
@@ -190,9 +191,9 @@ These functions take the form `define_extract_*()`:
 When you define an extract request, you can specify the data to be
 included in the extract and indicate the desired format and layout.
 
-For instance, the following defines a simple IPUMS USA extract request for 
-the `AGE`, `SEX`, `RACE`, `STATEFIP`, and `MARST` variables from the 2018 
-and 2019 American Community Survey (ACS):
+For instance, the following defines a simple IPUMS USA extract request
+for the `AGE`, `SEX`, `RACE`, `STATEFIP`, and `MARST` variables from the
+2018 and 2019 American Community Survey (ACS):
 
 ```{r}
 usa_ext_def <- define_extract_usa(
@@ -205,26 +206,27 @@ usa_ext_def
 ```
 
 The exact extract definition options vary across collections, but all
-collections can be used with the same general workflow. For more details 
-on the available extract definition options, see the associated 
-[microdata](ipums-api-micro.html) and [NHGIS](ipums-api-nhgis.html) vignettes. 
+collections can be used with the same general workflow. For more details
+on the available extract definition options, see the associated
+[microdata](ipums-api-micro.html) and [NHGIS](ipums-api-nhgis.html)
+vignettes.
 
-For the purposes of demonstrating the overall workflow, we will continue to
-work with the sample IPUMS USA extract definition created above.
+For the purposes of demonstrating the overall workflow, we will continue
+to work with the sample IPUMS USA extract definition created above.
 
 ### Extract request objects
 
-`define_extract_*()` functions always produce an `ipums_extract` object, which 
-can be handled by other API functions (see `?ipums_extract`). Furthermore, 
-these objects will have a subclass for the particular collection with which 
-they are associated.
+`define_extract_*()` functions always produce an `ipums_extract` object,
+which can be handled by other API functions (see `?ipums_extract`).
+Furthermore, these objects will have a subclass for the particular
+collection with which they are associated.
 
 ```{r}
 class(usa_ext_def)
 ```
 
-Many of the specifications for a given extract request object can be accessed
-by indexing the object:
+Many of the specifications for a given extract request object can be
+accessed by indexing the object:
 
 ```{r}
 names(usa_ext_def$samples)
@@ -235,9 +237,9 @@ usa_ext_def$data_format
 ```
 
 `ipums_extract` objects also contain information about the extract
-request's processing status and its assigned extract number, which serves as an
-identifier for the extract request. Since this extract request is still 
-unsubmitted, it has no request number:
+request's processing status and its assigned extract number, which
+serves as an identifier for the extract request. Since this extract
+request is still unsubmitted, it has no request number:
 
 ```{r}
 usa_ext_def$status
@@ -245,8 +247,8 @@ usa_ext_def$status
 usa_ext_def$number
 ```
 
-To obtain the data requested in the extract definition, we must first submit it
-to the IPUMS API for processing.
+To obtain the data requested in the extract definition, we must first
+submit it to the IPUMS API for processing.
 
 ## Submit an extract request {#submit}
 
@@ -300,18 +302,18 @@ usa_ext_submitted$number
 usa_ext_submitted$status
 ```
 
-Note that some fields of a submitted extract may be automatically updated by
-the API upon submission. For instance, for microdata extracts, additional
-preselected variables may be added to the extract even if they weren't
-specified explicitly in the extract definition.
+Note that some fields of a submitted extract may be automatically
+updated by the API upon submission. For instance, for microdata
+extracts, additional preselected variables may be added to the extract
+even if they weren't specified explicitly in the extract definition.
 
 ```{r}
 names(usa_ext_submitted$variables)
 ```
 
-If you forget to store the updated extract object returned by 
-`submit_extract()`, you can use the `get_last_extract_info()` helper to 
-request the information for your most recent extract request for a given 
+If you forget to store the updated extract object returned by
+`submit_extract()`, you can use the `get_last_extract_info()` helper to
+request the information for your most recent extract request for a given
 collection:
 
 ```{r}
@@ -327,11 +329,11 @@ eject_cassette("submit-extract")
 ## Wait for an extract request to complete {#wait}
 
 It may take some time for the IPUMS servers to process your extract
-request. You can ensure that an extract has finished processing before you 
-attempt to download its files by using `wait_for_extract()`. This polls the 
-API regularly until processing has completed (by default, each interval 
-increases by 10 seconds). It then returns an `ipums_extract` object containing
-the completed extract definition.
+request. You can ensure that an extract has finished processing before
+you attempt to download its files by using `wait_for_extract()`. This
+polls the API regularly until processing has completed (by default, each
+interval increases by 10 seconds). It then returns an `ipums_extract`
+object containing the completed extract definition.
 
 ```{r, echo=FALSE, results="hide", message=FALSE}
 insert_cassette("wait-for-extract")
@@ -366,13 +368,13 @@ eject_cassette("wait-for-extract")
 ```
 
 Note that `wait_for_extract()` will tie up your R session until your
-extract is ready to download. While this is fine in a strictly 
+extract is ready to download. While this is fine in a strictly
 programmatic workflow, it may be frustrating when working interactively,
 especially for large extracts or when the IPUMS servers are busy.
 
-In these cases, you can manually check whether an extract is ready for download
-with `is_extract_ready()`. As long as this returns `TRUE`, you should be able 
-to download your extract's files.
+In these cases, you can manually check whether an extract is ready for
+download with `is_extract_ready()`. As long as this returns `TRUE`, you
+should be able to download your extract's files.
 
 ```{r, echo=FALSE, results="hide", message=FALSE}
 insert_cassette("extract-ready")
@@ -386,12 +388,11 @@ is_extract_ready(usa_ext_submitted)
 eject_cassette("extract-ready")
 ```
 
-For a more detailed status check, provide the extract's collection and 
-number to `get_extract_info()`. This returns an `ipums_extract` object 
-reflecting the requested extract definition with
-the most current status. The `status` of a submitted extract will be
-one of `"queued"`, `"started"`, `"produced"`, `"canceled"`, `"failed"`,
-or `"completed"`.
+For a more detailed status check, provide the extract's collection and
+number to `get_extract_info()`. This returns an `ipums_extract` object
+reflecting the requested extract definition with the most current
+status. The `status` of a submitted extract will be one of `"queued"`,
+`"started"`, `"produced"`, `"canceled"`, `"failed"`, or `"completed"`.
 
 ```{r, echo=FALSE, results="hide", message=FALSE}
 insert_cassette("check-extract-info")
@@ -407,55 +408,57 @@ usa_ext_submitted$status
 eject_cassette("check-extract-info")
 ```
 
-Note that extracts are removed from the IPUMS servers after a set period of time
-(72 hours for microdata collections, 2 weeks for IPUMS NHGIS). Therefore,
-an extract that has a `"completed"` status may still be unavailable for
-download. 
+Note that extracts are removed from the IPUMS servers after a set period
+of time (72 hours for microdata collections, 2 weeks for IPUMS NHGIS).
+Therefore, an extract that has a `"completed"` status may still be
+unavailable for download.
 
-`is_extract_ready()` will alert you if the extract has expired
-and needs to be resubmitted. Simply use `submit_extract()` to resubmit an
-extract request. Note that this will produce a _new_ extract (with a new 
-extract number), even if the extract definition is identical.
+`is_extract_ready()` will alert you if the extract has expired and needs
+to be resubmitted. Simply use `submit_extract()` to resubmit an extract
+request. Note that this will produce a *new* extract (with a new extract
+number), even if the extract definition is identical.
 
 ## Download an extract {#download}
 
-Once your extract has finished processing, use `download_extract()`
-to download the extract's data files to your local machine. This will return 
-the path to the downloaded file(s) required to load the data into R.
+Once your extract has finished processing, use `download_extract()` to
+download the extract's data files to your local machine. This will
+return the path to the downloaded file(s) required to load the data into
+R.
 
-For microdata collections, this will be the path to the DDI
-codebook (.xml) file, which can be used to read the associated data
-(contained in a .dat.gz file). 
+For microdata collections, this will be the path to the DDI codebook
+(.xml) file, which can be used to read the associated data (contained in
+a .dat.gz file).
 
-For NHGIS, this will be a path to the .zip 
-archive containing the requested data files and/or shapefiles.
+For NHGIS, this will be a path to the .zip archive containing the
+requested data files and/or shapefiles.
 
 ```{r, eval=FALSE}
 # By default, downloads to your current working directory
 filepath <- download_extract(usa_ext_submitted)
 ```
 
-The files produced by `download_extract()` can be passed directly into the
-reader functions provided by ipumsr. For instance, for microdata projects:
+The files produced by `download_extract()` can be passed directly into
+the reader functions provided by ipumsr. For instance, for microdata
+projects:
 
 ```{r, eval=FALSE}
 ddi <- read_ipums_ddi(filepath)
 micro_data <- read_ipums_micro(ddi)
 ```
 
-If instead you're working with an NHGIS extract, use `read_nhgis()` or 
+If instead you're working with an NHGIS extract, use `read_nhgis()` or
 `read_ipums_sf()`.
 
-See the [associated vignette](ipums-read.html) for more information about 
-loading IPUMS data into R.
+See the [associated vignette](ipums-read.html) for more information
+about loading IPUMS data into R.
 
 ## Get info on past extracts {#recent}
 
-To retrieve the definition corresponding to a particular extract, provide
-its collection and number to `get_extract_info()`. These can be provided 
-either as a single string of the form `"collection:number"` or as a 
-length-2 vector: `c(collection, number)`. Several other API functions 
-support this syntax as well.
+To retrieve the definition corresponding to a particular extract,
+provide its collection and number to `get_extract_info()`. These can be
+provided either as a single string of the form `"collection:number"` or
+as a length-2 vector: `c(collection, number)`. Several other API
+functions support this syntax as well.
 
 ```{r, echo=FALSE, results="hide", message=FALSE}
 insert_cassette("check-extract-history")
@@ -471,13 +474,12 @@ usa_ext
 ```
 
 If you know you made a specific extract definition in the past, but you
-can't remember the exact number, you can use
-`get_extract_history()` to peruse your recent extract requests for
-a particular collection.
+can't remember the exact number, you can use `get_extract_history()` to
+peruse your recent extract requests for a particular collection.
 
 By default, this returns your 10 most recent extract requests as a list
-of `ipums_extract` objects. You can adjust how many requests to 
-retrieve with the `how_many` argument:
+of `ipums_extract` objects. You can adjust how many requests to retrieve
+with the `how_many` argument:
 
 ```{r}
 usa_extracts <- get_extract_history("usa", how_many = 3)
@@ -493,8 +495,9 @@ is_extract_ready(usa_extracts[[2]])
 ```
 
 You can also iterate through your extract history to find extracts with
-particular characteristics. For instance, we can use `purrr::keep()` to 
-find all extracts that contain a certain variable or are ready for download:
+particular characteristics. For instance, we can use `purrr::keep()` to
+find all extracts that contain a certain variable or are ready for
+download:
 
 ```{r}
 purrr::keep(usa_extracts, ~ "MARST" %in% names(.x$variables))
@@ -560,8 +563,8 @@ save_extract_as_json(usa_ext_10, file = "usa_extract_10.json")
 
 At this point, you can send `usa_extract_10.json` to another user to
 allow them to create a duplicate `ipums_extract` object, which they can
-load and submit to the API themselves (as long as they have 
-[API access](#set-key)).
+load and submit to the API themselves (as long as they have [API
+access](#set-key)).
 
 ```{r, eval=FALSE}
 clone_of_usa_ext_10 <- define_extract_from_json("usa_extract_10.json")
@@ -574,34 +577,34 @@ in the current working directory. If it's saved somewhere else, replace
 
 ## Revise a previous extract request
 
-Occasionally, you may want to modify an existing extract definition (e.g.
-to update an analysis with new data). The easiest way to do so is to add the
-new specifications to the `define_extract_*()` code that produced the original 
-extract definition. This is why we highly recommend that you save this code
-somewhere where it can be accessed and updated in the future.
+Occasionally, you may want to modify an existing extract definition
+(e.g. to update an analysis with new data). The easiest way to do so is
+to add the new specifications to the `define_extract_*()` code that
+produced the original extract definition. This is why we highly
+recommend that you save this code somewhere where it can be accessed and
+updated in the future.
 
-However, there are cases where the original extract definition code does not
-exist (e.g. if the extract was created using the online IPUMS extract system).
-In this case, the best approach is to view the extract definition with
-`get_extract_info()` and create a new extract definition
+However, there are cases where the original extract definition code does
+not exist (e.g. if the extract was created using the online IPUMS
+extract system). In this case, the best approach is to view the extract
+definition with `get_extract_info()` and create a new extract definition
 (using a `define_extract_*()` function) that reproduces that definition
-along with the desired modifications. While this
-may be a bit tedious for complex extract definitions, it is a one-time
-investment that will make any future updates to the extract
-definition much easier.
+along with the desired modifications. While this may be a bit tedious
+for complex extract definitions, it is a one-time investment that will
+make any future updates to the extract definition much easier.
 
-Previously, we encouraged users to use the helpers 
-`add_to_extract()` and `remove_from_extract()` when modifying extracts.
-We now encourage you to re-write extract definitions because they improve
+Previously, we encouraged users to use the helpers `add_to_extract()`
+and `remove_from_extract()` when modifying extracts. We now encourage
+you to re-write extract definitions because they improve
 reproducibility: extract definition code will always be more clear and
-stable if it is written explicitly, rather than based only on an old extract
-number. These two functions may be retired in the future.
+stable if it is written explicitly, rather than based only on an old
+extract number. These two functions may be retired in the future.
 
 ## Putting it all together
 
-The core API functions in ipumsr are compatible with one another
-such that they can be combined into a single pipeline that requests, downloads,
-and reads your extract data into an R data frame:
+The core API functions in ipumsr are compatible with one another such
+that they can be combined into a single pipeline that requests,
+downloads, and reads your extract data into an R data frame:
 
 ```{r, eval=FALSE}
 usa_data <- define_extract_usa(
@@ -615,10 +618,11 @@ usa_data <- define_extract_usa(
   read_ipums_micro()
 ```
 
-Note that for NHGIS extracts that contain both data and shapefiles, a single
-file will need to be selected before reading, as `download_extract()` will
-return the path to each file. For instance, for a 
-hypothetical `nhgis_extract` that contains both tabular and spatial data:
+Note that for NHGIS extracts that contain both data and shapefiles, a
+single file will need to be selected before reading, as
+`download_extract()` will return the path to each file. For instance,
+for a hypothetical `nhgis_extract` that contains both tabular and
+spatial data:
 
 ```{r, eval=FALSE}
 nhgis_data <- download_extract(nhgis_extract) %>%
@@ -626,8 +630,8 @@ nhgis_data <- download_extract(nhgis_extract) %>%
   read_nhgis()
 ```
 
-Not only does this API workflow allow you to obtain IPUMS data without ever
-leaving your R environment, but it also allows you to retain a
+Not only does this API workflow allow you to obtain IPUMS data without
+ever leaving your R environment, but it also allows you to retain a
 reproducible record of your process. This makes it much easier to
 document your workflow, collaborate with other researchers, and update
 your analysis in the future.

--- a/vignettes/ipums.Rmd
+++ b/vignettes/ipums.Rmd
@@ -1,9 +1,9 @@
 ---
-title: "IPUMS Data in R"
+title: "IPUMS Data and R"
 author: "Institute for Social Research and Data Innovation"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{IPUMS Data in R}
+  %\VignetteIndexEntry{IPUMS Data and R}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---
@@ -16,67 +16,77 @@ knitr::opts_chunk$set(
 library(ipumsr)
 ```
 
+This text provides an overview of how to find, request, download, and
+read IPUMS data into R. For a general introduction to IPUMS and ipumsr,
+see the [ipumsr home page](https://tech.popdata.org/ipumsr/index.html).
+
 ## Obtaining IPUMS data
 
 IPUMS data are free, but do require registration. New users can register
 with a particular [IPUMS project](https://www.ipums.org/overview) by
 clicking the **Register** link at the top right of the project website.
 
-IPUMS data are obtained by creating and submitting an *extract request*.
-This specifies the data to be included in the resulting *extract* (or
-*data extract*). A submitted extract request will be processed by the
-IPUMS servers. When complete, the extract containing the requested data
-can be downloaded.
+Users obtain IPUMS data by creating and submitting an *extract request*.
+This specifies which data to include in the resulting *extract* (or
+*data extract*). IPUMS servers process each submitted extract request,
+and when complete, users can download the extract containing the
+requested data.
 
 Extracts typically contain both data and metadata files. Data files
-typically come as .dat (for fixed-width files) or .csv (for
-comma-delimited files). Metadata files contain information about the
-data file and its contents, including variable descriptions and parsing
-instructions for fixed-width data files. Microdata projects provide
-metadata in DDI (.xml) files. Aggregate data projects provide metadata
-in either .txt or .csv formats.
+typically come as fixed-width (.dat) files or comma-delimited (.csv)
+files. Metadata files contain information about the data file and its
+contents, including variable descriptions and parsing instructions for
+fixed-width data files. IPUMS microdata projects provide metadata in DDI
+(.xml) files. Aggregate data projects provide metadata in either .txt or
+.csv formats.
 
-Registered users can download IPUMS data from a particular project
-through the interactive extract system found on that project's website.
-For some projects, data can also be downloaded within R by interacting
-with the IPUMS API.
+Users can submit extract requests and download extracts via either the
+IPUMS website or the IPUMS API, or via ipumsr functions that interface
+with the IPUMS API. The API currently supports access to the extract
+system only for [certain IPUMS
+projects](https://developer.ipums.org/docs/v2/apiprogram/apis/), which
+also determines the functionality that ipumsr can support.
 
-### Downloading via the IPUMS website
+### Obtaining data via an IPUMS website
 
-To create a new extract request, navigate to the extract interface for
-the IPUMS project of interest by clicking **Select Data** in the heading
-of the project website. The project extract interface allows you to
-specify the data you'd like to download. The data selection parameters
-will differ across projects; see each project's documentation for more
-details on the available options. If you've never created an extract for
-the project you're interested in, start by watching the project-specific
-video on creating extracts hosted on the [IPUMS Tutorials
+To create a new extract request via IPUMS websites, navigate to the
+extract interface for the IPUMS project of interest by clicking **Select
+Data** in the heading of the project website. The project extract
+interface allows you to explore what's available, find documentation
+about data concepts and sources, and then specify the data you'd like to
+download. The data selection parameters will differ across projects; see
+each project's documentation for more details on the available options.
+If you've never created an extract for the project you're interested in,
+a good way to learn the basics is to watch a project-specific video on
+creating extracts hosted on the [IPUMS Tutorials
 page](https://www.ipums.org/support/tutorials).
 
-#### For microdata projects
+#### Downloading from microdata projects
 
 Once your extract is ready, click the green **Download** button to
 download the data file. Then, right-click the **DDI** link in the
-codebook column, and select **Save Link As...** (see below).
+Codebook column, and select **Save Link As...** (see below).
 
 Note that some browsers may display different text, but there should be
 an option to download the DDI file as .xml. For instance, on Safari,
-select **Download Linked File As...**. The most important thing is that
-you download the file in .xml format, *not* .html format.
+select **Download Linked File As...**. For ipumsr to read the metadata,
+it is necessary to **save the file in .xml format, *not* .html format**.
 
 ![](microdata_annotated_screenshot.png){width="1000"}
 
-#### For aggregate data projects
+#### Downloading from aggregate data projects
 
-Simply download an extract's data by clicking the green **Tables**
-button (for tabular data) and/or **GIS Files** button (for spatial
-boundary data) in the **Download Data** column.
+Aggregate data projects include data and metadata together in a single
+.zip archive file. To download them, simply click on the green
+**Tables** button (for tabular data) and/or **GIS Files** button (for
+spatial boundary or location data) in the **Download Data** column.
 
-### Downloading via the IPUMS API
+### Obtaining data via the IPUMS API
 
-Extract requests can also be created and submitted from within R by
-interacting with the IPUMS API. The IPUMS API currently supports the
-following collections:
+Users can also create and submit extract requests within R by using
+ipumsr functions that interface with the IPUMS API. The IPUMS API
+currently supports access to the extract system for the following
+collections:
 
 -   IPUMS USA
 
@@ -86,12 +96,21 @@ following collections:
 
 -   IPUMS NHGIS
 
-The workflow for requesting and downloading data via API is
-straightforward. First, define the parameters of your extract. The available 
-extract definition options will differ by IPUMS data collection. 
-See the [microdata API request](ipums-api-micro.html) and 
-[NHGIS API request](ipums-api-nhgis.html) vignettes for more details on
-defining an extract.
+The IPUMS API and ipumsr also support access to IPUMS NHGIS metadata, so
+users can query NHGIS metadata in R to explore what data are available
+and specify NHGIS data requests. At this time, creating requests for
+microdata generally requires using the corresponding project websites to
+find samples and variables of interest and obtain their identifiers for
+use in R extract definitions.
+
+Once you have identified the data you would like to request, the
+workflow for requesting and downloading data via API is straightforward.
+First, define the parameters of your extract. The available extract
+definition options will differ by IPUMS data collection. See the
+[microdata API request](ipums-api-micro.html) and [NHGIS API
+request](ipums-api-nhgis.html) vignettes for more details on defining an
+extract. (The NHGIS vignette also discusses how to access NHGIS
+metadata.)
 
 ```{r}
 cps_extract_request <- define_extract_cps(
@@ -110,9 +129,9 @@ nhgis_extract_request <- define_extract_nhgis(
 )
 ```
 
-Next, submit your extract definition. After waiting for it to complete, you 
-can download the files directly to your local machine without ever having to 
-leave R:
+Next, submit your extract definition. After waiting for it to complete,
+you can download the files directly to your local machine without ever
+having to leave R:
 
 ```{r, eval = FALSE}
 submitted_extract <- submit_extract(extract_request)
@@ -120,32 +139,32 @@ downloadable_extract <- wait_for_extract(submitted_extract)
 data_files <- download_extract(downloadable_extract)
 ```
 
-You can also get the specifications of your previous extract requests, even if 
-they weren't made with the API:
+You can also get the specifications of your previous extract requests,
+even if they weren't made with the API:
 
 ```{r, eval=FALSE}
 past_extracts <- get_extract_history("nhgis")
 ```
 
-See the [introduction to the IPUMS API](ipums-api.html) for more details 
-about how to use ipumsr to interact with the IPUMS API.
+See the [introduction to the IPUMS API for R users](ipums-api.html) for
+more details about how to use ipumsr to interact with the IPUMS API.
 
 ## Reading IPUMS data
 
-Once your extract is downloaded, you can load your data into R with the
-family of `read_*()` functions in ipumsr. These functions expand on
+Once you have downloaded an extract, you can load the data into R with
+the family of `read_*()` functions in ipumsr. These functions expand on
 those provided in [readr](https://readr.tidyverse.org/index.html) in two
 ways:
 
 -   ipumsr anticipates standard IPUMS file structures, limiting the need
-for users to manually extract and organize their downloaded files
-before reading.
+    for users to manually extract and organize their downloaded files
+    before reading.
 
 -   ipumsr uses an extract's metadata files to automatically attach
-contextual information to the data. This allows users to easily
-identify variable names, variable descriptions, and labeled data
-values (from [haven](https://haven.tidyverse.org/)), which are
-common in IPUMS files.
+    contextual information to the data. This allows users to easily
+    identify variable names, variable descriptions, and labeled data
+    values (from [haven](https://haven.tidyverse.org/)), which are
+    common in IPUMS files.
 
 For microdata files, use the `read_ipums_micro_*()` family:
 
@@ -165,9 +184,9 @@ nhgis_data <- read_nhgis(nhgis_file)
 head(nhgis_data)
 ```
 
-ipumsr also supports the reading of IPUMS spatial boundary files into
-the `sf` format provided by the [sf](https://r-spatial.github.io/sf/)
-package:
+ipumsr also supports the reading of IPUMS shapefiles (spatial boundary
+and location files) into the `sf` format provided by the
+[sf](https://r-spatial.github.io/sf/) package:
 
 ```{r, eval = requireNamespace("sf")}
 shp_file <- ipums_example("nhgis0972_shape_small.zip")
@@ -184,13 +203,13 @@ packages like [readr](https://readr.tidyverse.org/) (for delimited
 files) or [haven](https://haven.tidyverse.org/) (for Stata, SPSS, or SAS
 files).
 
-See the [vignette](ipums-read.html) on reading IPUMS data for
-more information.
+See the vignette on [reading IPUMS data](ipums-read.html) for more
+information.
 
 ### Exploring file metadata
 
-Load a file's metadata with `read_ipums_ddi()` (for microdata
-projects) and `read_nhgis_codebook()` (for NHGIS). These provide file- and
+Load a file's metadata with `read_ipums_ddi()` (for microdata projects)
+and `read_nhgis_codebook()` (for NHGIS). These provide file- and
 variable-level metadata for a given data source, which can be used to
 interpret the data contents.
 


### PR DESCRIPTION
Some functions allowed users to read files by providing the path to their containing directory. As functionality for combining multiple files has been scaled back, this feature is less useful, but requires internal maintenance. For users who unzip their extract files, they can provide the direct path the decompressed files.

Additionally, microdata DDI files could be read through a zip archive, similarly to NHGIS extracts. However, DDI files are not provided in zipped format, and the `ipums_ddi` objects produced by doing point to data files that are not within the same containing zip archive, meaning that `read_ipums_micro_*()` functions often have difficulty finding the associated data file if the DDI file has been loaded through a zip archive. This functionality has also been deprecated, such that DDI files must be read with their direct file path.