### PR TITLE
Update DBI/RSQLite chunk eval logic

### DIFF
--- a/vignettes/ipums-bigdata.Rmd
+++ b/vignettes/ipums-bigdata.Rmd
@@ -48,6 +48,21 @@ installed_biglm <- requireNamespace("biglm")
 installed_db_pkgs <- requireNamespace("DBI") &
   requireNamespace("RSQLite") &
   requireNamespace("dbplyr")
+
+# Suppress certain chunks when on CRAN, as they may fail due to
+# bug in vroom 1.6.4 that interacts with RSQLite and DBI 
+# (https://github.com/tidyverse/vroom/issues/519).
+# 
+# Until bug is fixed in vroom, we do not want vignette check failures 
+# on CRAN that are out of our control, so we suppress output from these chunks
+#
+# Developers can use dev version of RSQLite to avoid errors. To run the chunks
+# if you have the appropriate version of RSQLite installed, set the
+# `NOT_CRAN` environment variable equal to `"true"`.
+#
+# TODO: remove when vroom is fixed
+installed_db_pkgs <- installed_db_pkgs &&
+  isTRUE(as.logical(Sys.getenv("NOT_CRAN", "false")))
 ```
 
 ```{r, echo=FALSE}
@@ -619,7 +634,7 @@ query, but the data still exist only in the database. You can use
 current R session. However, this would omit the variable metadata
 attached to IPUMS data, since the database doesn't store this metadata:
 
-```{r}
+```{r, eval=installed_db_pkgs}
 data <- example %>%
   filter("AGE" > 25) %>%
   collect()


### PR DESCRIPTION
Uses `NOT_CRAN` env var to suppress certain chunks in ipums-bigdata.Rmd that may produce CRAN check errors until vroom "bad value" (#519) bug is fixed.