### PR TITLE
Clarify requirements for `ipums_view()`

### DIFF
--- a/R/viewer.R
+++ b/R/viewer.R
@@ -3,26 +3,48 @@
 # in this project's top-level directory, and also on-line at:
 #   https://github.com/ipums/ipumsr
 
-#' View a static webpage with variable information from a IPUMS extract
+#' View a static webpage with variable metadata from an IPUMS extract
 #'
-#' Requires that htmltools, shiny and DT are installed.
+#' @description
+#' For a given [`ipums_ddi`] object or data frame, display metadata about
+#' its contents in the RStudio viewer pane. This includes extract-level
+#' information as well as metadata for the variables included in the
+#' input object.
 #'
-#' @param x An [ipums_ddi] object or a data frame with IPUMS attributes
+#' It is also possible to save the output to an external HTML file without
+#' launching the RStudio viewer.
+#'
+#' @details
+#' `ipums_view()` requires that the htmltools, shiny, and DT packages are
+#' installed. If `launch = TRUE`, RStudio and the rstudioapi package must
+#' also be available.
+#'
+#' Note that if `launch = FALSE` and `out_file` is unspecified, the output
+#' file will be written to a temporary directory. Some operating systems
+#' may be unable to open the HTML file from the temporary directory; we
+#' suggest that you manually specify the `out_file` location in this case.
+#'
+#' @param x An `ipums_ddi` object or a data frame with IPUMS attributes
 #'   attached.
 #'
-#'   Note that the file-level information (e.g. extract notes) are only
-#'   available when providing an `ipums_ddi` object.
-#' @param out_file Optional location to save produced HTML file. If `NULL`,
+#'   Note that file-level information (e.g. extract notes) is only
+#'   available when `x` is an `ipums_ddi` object.
+#' @param out_file Optional location to save the output HTML file. If `NULL`,
 #'   makes a temporary file.
-#' @param launch Logical indicating whether to launch the website.
-#' @return The filepath to the html (silently if `launch = TRUE`)
+#' @param launch Logical indicating whether to launch the HTML file in the
+#'   RStudio viewer pane. If `TRUE`, RStudio and rstudioapi must be available.
+#'
+#' @return The file path to the output HTML file (invisibly, if `launch = TRUE`)
+#'
+#' @export
+#'
 #' @examples
 #' ddi <- read_ipums_ddi(ipums_example("cps_00157.xml"))
+#'
 #' \dontrun{
 #' ipums_view(ddi)
 #' ipums_view(ddi, "codebook.html", launch = FALSE)
 #' }
-#' @export
 ipums_view <- function(x, out_file = NULL, launch = TRUE) {
   if (!requireNamespace("htmltools", quietly = TRUE) ||
     !requireNamespace("shiny", quietly = TRUE) ||
@@ -37,6 +59,14 @@ ipums_view <- function(x, out_file = NULL, launch = TRUE) {
   }
 
   if (is.null(out_file)) {
+    if (!launch) {
+      rlang::warn(c(
+        paste0("Some operating systems may have trouble opening an HTML ",
+               "file from a temporary directory."),
+        "i" = "Use `out_file` to specify an alternate output location."
+      ))
+    }
+
     out_file <- paste0(tempfile(), ".html")
   }
 
@@ -65,7 +95,7 @@ ipums_view <- function(x, out_file = NULL, launch = TRUE) {
       rstudioapi::viewer(out_file)
     } else {
       rlang::abort(c(
-        "RStudio and the rstudioapi package are required to use `ipums_view()`",
+        "RStudio and the rstudioapi package are required when `launch = TRUE`",
         "i" = "Install rstudioapi with `install.packages(\"rstudioapi\")`"
       ))
     }

--- a/man/ipums_view.Rd
+++ b/man/ipums_view.Rd
@@ -2,30 +2,48 @@
 % Please edit documentation in R/viewer.R
 \name{ipums_view}
 \alias{ipums_view}
-\title{View a static webpage with variable information from a IPUMS extract}
+\title{View a static webpage with variable metadata from an IPUMS extract}
 \usage{
 ipums_view(x, out_file = NULL, launch = TRUE)
 }
 \arguments{
-\item{x}{An \link{ipums_ddi} object or a data frame with IPUMS attributes
+\item{x}{An \code{ipums_ddi} object or a data frame with IPUMS attributes
 attached.
 
-Note that the file-level information (e.g. extract notes) are only
-available when providing an \code{ipums_ddi} object.}
+Note that file-level information (e.g. extract notes) is only
+available when \code{x} is an \code{ipums_ddi} object.}
 
-\item{out_file}{Optional location to save produced HTML file. If \code{NULL},
+\item{out_file}{Optional location to save the output HTML file. If \code{NULL},
 makes a temporary file.}
 
-\item{launch}{Logical indicating whether to launch the website.}
+\item{launch}{Logical indicating whether to launch the HTML file in the
+RStudio viewer pane. If \code{TRUE}, RStudio and rstudioapi must be available.}
 }
 \value{
-The filepath to the html (silently if \code{launch = TRUE})
+The file path to the output HTML file (invisibly, if \code{launch = TRUE})
 }
 \description{
-Requires that htmltools, shiny and DT are installed.
+For a given \code{\link{ipums_ddi}} object or data frame, display metadata about
+its contents in the RStudio viewer pane. This includes extract-level
+information as well as metadata for the variables included in the
+input object.
+
+It is also possible to save the output to an external HTML file without
+launching the RStudio viewer.
+}
+\details{
+\code{ipums_view()} requires that the htmltools, shiny, and DT packages are
+installed. If \code{launch = TRUE}, RStudio and the rstudioapi package must
+also be available.
+
+Note that if \code{launch = FALSE} and \code{out_file} is unspecified, the output
+file will be written to a temporary directory. Some operating systems
+may be unable to open the HTML file from the temporary directory; we
+suggest that you manually specify the \code{out_file} location in this case.
 }
 \examples{
 ddi <- read_ipums_ddi(ipums_example("cps_00157.xml"))
+
 \dontrun{
 ipums_view(ddi)
 ipums_view(ddi, "codebook.html", launch = FALSE)


### PR DESCRIPTION
Docs and error messages suggested that rstudioapi and RStudio were required, when they are only technically required if `launch = TRUE`. This updates docs and error/warning messages to clarify appropriate use of this function.