### PR TITLE
Enable big data chunk output on CRAN

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -48,7 +48,7 @@ Suggests:
     knitr,
     rmapshaper,
     rmarkdown,
-    RSQLite,
+    RSQLite (>= 2.3.3),
     rstudioapi,
     scales,
     sf,

--- a/vignettes/ipums-bigdata.Rmd
+++ b/vignettes/ipums-bigdata.Rmd
@@ -48,21 +48,6 @@ installed_biglm <- requireNamespace("biglm")
 installed_db_pkgs <- requireNamespace("DBI") &
   requireNamespace("RSQLite") &
   requireNamespace("dbplyr")
-
-# Suppress certain chunks when on CRAN, as they may fail due to
-# bug in vroom 1.6.4 that interacts with RSQLite and DBI 
-# (https://github.com/tidyverse/vroom/issues/519).
-# 
-# Until bug is fixed in vroom, we do not want vignette check failures 
-# on CRAN that are out of our control, so we suppress output from these chunks
-#
-# Developers can use dev version of RSQLite to avoid errors. To run the chunks
-# if you have the appropriate version of RSQLite installed, set the
-# `NOT_CRAN` environment variable equal to `"true"`.
-#
-# TODO: remove when vroom is fixed
-installed_db_pkgs <- installed_db_pkgs &&
-  isTRUE(as.logical(Sys.getenv("NOT_CRAN", "false")))
 ```
 
 ```{r, echo=FALSE}


### PR DESCRIPTION
Developers must have RSQLite > 2.3.3 to generate big-data vignette chunk output, but this is not required for ipumsr functionality