### PR TITLE
Add geographic extent example to NHGIS docs

### DIFF
--- a/R/api_define_extract.R
+++ b/R/api_define_extract.R
@@ -557,6 +557,16 @@ define_extract_ipumsi <- function(description,
 #'   shapefiles = "us_county_1990_tl2008"
 #' )
 #'
+#' # Geographic extents are applied to all datasets in the definition
+#' define_extract_nhgis(
+#'   description = "Extent selection",
+#'   datasets = list(
+#'     ds_spec("2018_2022_ACS5a", "B01001", "blck_grp"),
+#'     ds_spec("2017_2021_ACS5a", "B01001", "blck_grp")
+#'   ),
+#'   geographic_extents = c("010", "050")
+#' )
+#'
 #' # Extract specifications can be indexed by name
 #' names(nhgis_extract$datasets)
 #'

--- a/man/define_extract_nhgis.Rd
+++ b/man/define_extract_nhgis.Rd
@@ -173,6 +173,16 @@ define_extract_nhgis(
   shapefiles = "us_county_1990_tl2008"
 )
 
+# Geographic extents are applied to all datasets in the definition
+define_extract_nhgis(
+  description = "Extent selection",
+  datasets = list(
+    ds_spec("2018_2022_ACS5a", "B01001", "blck_grp"),
+    ds_spec("2017_2021_ACS5a", "B01001", "blck_grp")
+  ),
+  geographic_extents = c("010", "050")
+)
+
 # Extract specifications can be indexed by name
 names(nhgis_extract$datasets)
 


### PR DESCRIPTION
Adds example to clarify that extent selection is not a dataset-specific option at this time