### PR TITLE
Update documentation for expanded NHGIS extent selection

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # ipumsr (development version)
 
+-   The `"*"` wildcard is no longer required to select all `geographic_extents`
+    in `define_extract_nhgis()`. Instead, all available geographic extents
+    are selected by default. The `"*"` syntax is still supported.
+
 -   Adds `download_supplemental_data()` to enable access to supplemental
     data files via the IPUMS API.
 

--- a/R/api_define_extract.R
+++ b/R/api_define_extract.R
@@ -441,14 +441,12 @@ define_extract_ipumsi <- function(description,
 #' @param shapefiles Names of any [shapefiles](https://www.nhgis.org/gis-files)
 #'   to include in the extract request.
 #' @param geographic_extents Vector of geographic extents to use for
-#'   all of the `datasets` in the extract definition (for instance, to obtain
-#'   data within a particular state). Use `"*"` to select all available extents.
+#'   all of the `datasets` and `time_series_tables` in the extract
+#'   definition (for instance, to obtain data within a specified state).
+#'   By default, selects all available extents.
 #'
-#'   Required when any of the `datasets` included in the extract definition
-#'   include `geog_levels` that require extent selection. See
-#'   [get_metadata_nhgis()] to determine if a geographic level requires extent
-#'   selection. At the time of writing, NHGIS supports extent selection only
-#'   for blocks and block groups.
+#'   Use [get_metadata_nhgis()] to identify the available extents for a given
+#'   dataset or time series table, if any.
 #' @param breakdown_and_data_type_layout The desired layout
 #'   of any `datasets` that have multiple data types or breakdown values.
 #'
@@ -557,7 +555,8 @@ define_extract_ipumsi <- function(description,
 #'   shapefiles = "us_county_1990_tl2008"
 #' )
 #'
-#' # Geographic extents are applied to all datasets in the definition
+#' # Geographic extents are applied to all datasets/time series tables in the
+#' # definition
 #' define_extract_nhgis(
 #'   description = "Extent selection",
 #'   datasets = list(

--- a/R/api_helpers.R
+++ b/R/api_helpers.R
@@ -547,16 +547,6 @@ print.nhgis_extract <- function(x, ...) {
     }
   )
 
-  if (length(ds_to_cat) > 0) {
-    ds_to_cat <- c(
-      ds_to_cat,
-      format_field_for_printing(
-        parent_field = list("Geographic extents: " = x$geographic_extents),
-        parent_style = style_ds
-      )
-    )
-  }
-
   tst_to_cat <- purrr::map(
     x$time_series_tables,
     function(t) {
@@ -575,6 +565,18 @@ print.nhgis_extract <- function(x, ...) {
     }
   )
 
+  ds_tst_to_cat <- c(ds_to_cat, tst_to_cat)
+
+  if (length(ds_tst_to_cat) > 0) {
+    ds_tst_to_cat <- c(
+      ds_tst_to_cat,
+      format_field_for_printing(
+        parent_field = list("Geographic extents: " = x$geographic_extents),
+        parent_style = extract_field_styler("italic")
+      )
+    )
+  }
+
   shp_to_cat <- format_field_for_printing(
     parent_field = list("Shapefiles: " = x$shapefiles),
     parent_style = extract_field_styler(
@@ -592,8 +594,7 @@ print.nhgis_extract <- function(x, ...) {
   to_cat <- paste0(
     header,
     print_truncated_vector(x$description, "Description: ", FALSE),
-    paste0(ds_to_cat, collapse = ""),
-    paste0(tst_to_cat, collapse = ""),
+    paste0(ds_tst_to_cat, collapse = ""),
     shp_to_cat
   )
 

--- a/R/api_metadata.R
+++ b/R/api_metadata.R
@@ -105,6 +105,11 @@
 #' - **`geog_levels`:** A [`tibble`][tibble::tbl_df-class] containing names
 #'   and descriptions for the geographic levels available
 #'   for the time series table.
+#' - **`geographic_instances`:** A [`tibble`][tibble::tbl_df-class] containing
+#'   names and descriptions for all valid geographic extents for the
+#'   time series table. Includes all states or state equivalents that are
+#'   valid for *any* year in the time series table. (Some instances may be valid
+#'   for some but not all years.)
 #'
 #' ## Shapefiles:
 #'

--- a/R/shape_read.R
+++ b/R/shape_read.R
@@ -81,7 +81,7 @@
 #' read_ipums_sf(shape_ex2, file_select = matches("us_pmsa_1990"))
 #'
 #' # Or row-bind files with `bind_multiple`. This may be useful for files of
-#' # the same geographic level that cover different extents)
+#' # the same geographic level that cover different extents
 #' read_ipums_sf(
 #'   shape_ex2,
 #'   file_select = matches("us_pmsa"),

--- a/ipumsr.Rproj
+++ b/ipumsr.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: e8f41f8e-2d1d-473e-b0ee-f96cb0faf1e0
 
 RestoreWorkspace: No
 SaveWorkspace: No

--- a/man/add_to_extract.nhgis_extract.Rd
+++ b/man/add_to_extract.nhgis_extract.Rd
@@ -40,14 +40,12 @@ specifications will be added to those that already exist for that time
 series table.}
 
 \item{geographic_extents}{Vector of geographic extents to use for
-all of the \code{datasets} in the extract definition (for instance, to obtain
-data within a particular state). Use \code{"*"} to select all available extents.
+all of the \code{datasets} and \code{time_series_tables} in the extract
+definition (for instance, to obtain data within a specified state).
+By default, selects all available extents.
 
-Required when any of the \code{datasets} included in the extract definition
-include \code{geog_levels} that require extent selection. See
-\code{\link[=get_metadata_nhgis]{get_metadata_nhgis()}} to determine if a geographic level requires extent
-selection. At the time of writing, NHGIS supports extent selection only
-for blocks and block groups.}
+Use \code{\link[=get_metadata_nhgis]{get_metadata_nhgis()}} to identify the available extents for a given
+dataset or time series table, if any.}
 
 \item{shapefiles}{Names of any \href{https://www.nhgis.org/gis-files}{shapefiles}
 to include in the extract request.}

--- a/man/define_extract_nhgis.Rd
+++ b/man/define_extract_nhgis.Rd
@@ -33,14 +33,12 @@ examples.}
 to include in the extract request.}
 
 \item{geographic_extents}{Vector of geographic extents to use for
-all of the \code{datasets} in the extract definition (for instance, to obtain
-data within a particular state). Use \code{"*"} to select all available extents.
+all of the \code{datasets} and \code{time_series_tables} in the extract
+definition (for instance, to obtain data within a specified state).
+By default, selects all available extents.
 
-Required when any of the \code{datasets} included in the extract definition
-include \code{geog_levels} that require extent selection. See
-\code{\link[=get_metadata_nhgis]{get_metadata_nhgis()}} to determine if a geographic level requires extent
-selection. At the time of writing, NHGIS supports extent selection only
-for blocks and block groups.}
+Use \code{\link[=get_metadata_nhgis]{get_metadata_nhgis()}} to identify the available extents for a given
+dataset or time series table, if any.}
 
 \item{breakdown_and_data_type_layout}{The desired layout
 of any \code{datasets} that have multiple data types or breakdown values.
@@ -173,7 +171,8 @@ define_extract_nhgis(
   shapefiles = "us_county_1990_tl2008"
 )
 
-# Geographic extents are applied to all datasets in the definition
+# Geographic extents are applied to all datasets/time series tables in the
+# definition
 define_extract_nhgis(
   description = "Extent selection",
   datasets = list(

--- a/man/get_metadata_nhgis.Rd
+++ b/man/get_metadata_nhgis.Rd
@@ -149,6 +149,11 @@ time series table.
 \item \strong{\code{geog_levels}:} A \code{\link[tibble:tbl_df-class]{tibble}} containing names
 and descriptions for the geographic levels available
 for the time series table.
+\item \strong{\code{geographic_instances}:} A \code{\link[tibble:tbl_df-class]{tibble}} containing
+names and descriptions for all valid geographic extents for the
+time series table. Includes all states or state equivalents that are
+valid for \emph{any} year in the time series table. (Some instances may be valid
+for some but not all years.)
 }
 }
 

--- a/man/read_ipums_sf.Rd
+++ b/man/read_ipums_sf.Rd
@@ -94,7 +94,7 @@ shape_ex2 <- ipums_example("nhgis0712_shape_small.zip")
 read_ipums_sf(shape_ex2, file_select = matches("us_pmsa_1990"))
 
 # Or row-bind files with `bind_multiple`. This may be useful for files of
-# the same geographic level that cover different extents)
+# the same geographic level that cover different extents
 read_ipums_sf(
   shape_ex2,
   file_select = matches("us_pmsa"),

--- a/tests/testthat/_snaps/api_helpers.md
+++ b/tests/testthat/_snaps/api_helpers.md
@@ -1,0 +1,79 @@
+# Can print microdata extracts
+
+    Code
+      print(test_usa_extract())
+    Output
+      Unsubmitted IPUMS USA extract 
+      Description: Test USA extract
+      
+      Samples: (1 total) us2017b
+      Variables: (2 total) RACE, YEAR
+
+---
+
+    Code
+      print(test_cps_extract())
+    Output
+      Unsubmitted IPUMS CPS extract 
+      Description: Compare age-sex-race breakdowns 1976
+      
+      Samples: (2 total) cps2018_03s, cps2019_03s
+      Variables: (3 total) AGE, SEX, RACE
+
+---
+
+    Code
+      print(test_ipumsi_extract())
+    Output
+      Unsubmitted IPUMS International extract 
+      Description: Test IPUMSI extract
+      
+      Samples: (2 total) mx2015a, cl2017a
+      Variables: (3 total) AGE, SEX, EDATTAIN
+
+---
+
+    Code
+      print(test_atus_extract())
+    Output
+      Unsubmitted IPUMS ATUS extract 
+      Description: Test ATUS extract
+      
+      Samples: (2 total) at2020, at2021
+      Variables: (5 total) STATEFIP, AGE, SEX, DIFFANY, RELATER
+      Time Use Variables: (2 total) ACT_PCARE, my_time_use_var
+
+# Can print NHGIS extracts
+
+    Code
+      print(test_nhgis_extract())
+    Output
+      Unsubmitted IPUMS NHGIS extract 
+      Description: Extract for R client testing
+      
+      Dataset: 2014_2018_ACS5a
+        Tables: B01001, B01002
+        Geog Levels: nation
+      
+      Dataset: 2015_2019_ACS5a
+        Tables: B01001, B01002
+        Geog Levels: blck_grp
+      
+      Time Series Table: CW3
+        Geog Levels: state
+        Years: 1990
+      
+      Geographic extents: 110, 100
+      
+      Shapefiles: 110_blck_grp_2019_tl2019
+
+---
+
+    Code
+      print(test_nhgis_extract_shp())
+    Output
+      Unsubmitted IPUMS NHGIS extract 
+      Description: 
+      
+      Shapefiles: 110_blck_grp_2019_tl2019
+

--- a/tests/testthat/test_api_helpers.R
+++ b/tests/testthat/test_api_helpers.R
@@ -72,11 +72,11 @@ test_that("Can print NHGIS extracts", {
       "\n  Tables: B01001, B01002",
       "\n  Geog Levels: blck_grp",
       "\n",
-      "\nGeographic extents: 110, 100",
-      "\n",
       "\nTime Series Table: CW3",
       "\n  Geog Levels: state",
       "\n  Years: 1990",
+      "\n",
+      "\nGeographic extents: 110, 100",
       "\n",
       "\nShapefiles: 110_blck_grp_2019_tl2019"
     )

--- a/tests/testthat/test_api_helpers.R
+++ b/tests/testthat/test_api_helpers.R
@@ -1,47 +1,10 @@
 # Print extract ------------------------
 
 test_that("Can print microdata extracts", {
-  expect_output(
-    print(test_usa_extract()),
-    paste0(
-      "Unsubmitted IPUMS USA extract.+",
-      "Description: Test.+",
-      "\n",
-      "Samples: .+",
-      "Variables: .+"
-    )
-  )
-  expect_output(
-    print(test_cps_extract()),
-    paste0(
-      "Unsubmitted IPUMS CPS extract.+",
-      "Description: Compare.+",
-      "\n",
-      "Samples: .+",
-      "Variables: .+"
-    )
-  )
-  expect_output(
-    print(test_ipumsi_extract()),
-    paste0(
-      "Unsubmitted IPUMS International extract.+",
-      "Description: Test.+",
-      "\n",
-      "Samples: .+",
-      "Variables: .+"
-    )
-  )
-  expect_output(
-    print(test_atus_extract()),
-    paste0(
-      "Unsubmitted IPUMS ATUS extract.+",
-      "Description: Test.+",
-      "\n",
-      "Samples: .+",
-      "Variables: .+",
-      "Time Use Variables: .+"
-    )
-  )
+  expect_snapshot(print(test_usa_extract()))
+  expect_snapshot(print(test_cps_extract()))
+  expect_snapshot(print(test_ipumsi_extract()))
+  expect_snapshot(print(test_atus_extract()))
 })
 
 test_that("Printing excludes Variables field if empty", {
@@ -58,38 +21,8 @@ test_that("Printing excludes Variables field if empty", {
 })
 
 test_that("Can print NHGIS extracts", {
-  expect_output(
-    print(test_nhgis_extract()),
-    paste0(
-      "Unsubmitted IPUMS NHGIS extract ",
-      "\nDescription: Extract for R client testing",
-      "\n",
-      "\nDataset: 2014_2018_ACS5a",
-      "\n  Tables: B01001, B01002",
-      "\n  Geog Levels: nation",
-      "\n",
-      "\nDataset: 2015_2019_ACS5a",
-      "\n  Tables: B01001, B01002",
-      "\n  Geog Levels: blck_grp",
-      "\n",
-      "\nTime Series Table: CW3",
-      "\n  Geog Levels: state",
-      "\n  Years: 1990",
-      "\n",
-      "\nGeographic extents: 110, 100",
-      "\n",
-      "\nShapefiles: 110_blck_grp_2019_tl2019"
-    )
-  )
-  expect_output(
-    print(test_nhgis_extract_shp()),
-    paste0(
-      "Unsubmitted IPUMS NHGIS extract ",
-      "\nDescription: ",
-      "\n",
-      "\nShapefiles: 110_blck_grp_2019_tl2019"
-    )
-  )
+  expect_snapshot(print(test_nhgis_extract()))
+  expect_snapshot(print(test_nhgis_extract_shp()))
 })
 
 test_that("NHGIS extract print coloring works", {


### PR DESCRIPTION
NHGIS now allows extent selection for all geog units that nest within states, which contradicts our current documentation that indicates extents are only available for block and block group level data.

Extents are also now applied to time series tables, requiring documentation updates as well as an update to the print method for NHGIS extracts to display extents for time series table extracts.

Finally, the `"*"` wildcard is no longer required, as all extents are selected by default.