### PR TITLE
Use UTF-8 as IHGIS default encoding

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,11 @@
     -   `read_ipums_agg()` loads downloaded extracts for both NHGIS and IHGIS.
         This replaces `read_nhgis()`, which is now deprecated.
         
+        `read_ipums_agg()` also includes a new `file_encoding` argument, as
+        IHGIS and NHGIS files often have different encoding. Typically,
+        the default `file_encoding` should load an aggregate data extract
+        file correctly. If not, you can adjust the encoding here.
+        
     -   `define_extract_agg()` defines extract requests for both NHGIS and
         IHGIS. Use the `collection` argument to specify the data collection for
         a given extract. This replaces `define_extract_nhgis()`, which is now

--- a/man/read_ipums_agg.Rd
+++ b/man/read_ipums_agg.Rd
@@ -13,6 +13,7 @@ read_ipums_agg(
   guess_max = min(n_max, 1000),
   var_attrs = c("val_labels", "var_label", "var_desc"),
   remove_extra_header = TRUE,
+  file_encoding = NULL,
   verbose = TRUE
 )
 }
@@ -68,6 +69,10 @@ This header row is not
 usually needed as it contains similar information to that
 included in the \code{"label"} attribute of each data column (if \code{var_attrs}
 includes \code{"var_label"}).}
+
+\item{file_encoding}{Encoding for the file to be loaded. For NHGIS extracts,
+defaults to ISO-8859-1. For IHGIS extracts, defaults to UTF-8. If the
+default encoding produces unexpected characters, adjust the encoding here.}
 
 \item{verbose}{Logical controlling whether to display output when loading
 data. If \code{TRUE}, displays IPUMS conditions, a progress bar, and


### PR DESCRIPTION
IHGIS files don't use latin1 encoding like NHGIS files do. Updates the default encoding used for IHGIS and exposes a `file_encoding` argument to allow users to adjust if certain files have different encoding.